### PR TITLE
Fix fluent negation

### DIFF
--- a/test/lib/Assertion.test.ts
+++ b/test/lib/Assertion.test.ts
@@ -70,6 +70,26 @@ function falsyAsText(value: typeof FALSY_VALUES[number]): string {
 }
 
 describe("[Unit] Assertion.test.ts", () => {
+  describe(".not", () => {
+    context("when .not is used before the assertion", () => {
+      context("and another assertion is append without a .not", () => {
+        it("does not negate the next assertion", () => {
+          const test = new Assertion(null);
+
+          assert.deepStrictEqual(test.not.toBeTruthy().toBeNull(), test);
+        });
+      });
+
+      context("and another assertion is append with a .not", () => {
+        it("negates the next assertion", () => {
+          const test = new Assertion("foo");
+
+          assert.deepStrictEqual(test.not.toBeFalsy().not.toBeEqual(""), test);
+        });
+      });
+    });
+  });
+
   describe(".toMatch", () => {
     const matcher = (actual: string): boolean => actual.startsWith("h");
 
@@ -93,7 +113,7 @@ describe("[Unit] Assertion.test.ts", () => {
           message: "Expected matcher function to return true",
           name: ASSERTION_ERROR
         });
-        assert.deepStrictEqual(test.not.toMatch(matcher), test.not);
+        assert.deepStrictEqual(test.not.toMatch(matcher), test);
       });
     });
   });
@@ -120,7 +140,7 @@ describe("[Unit] Assertion.test.ts", () => {
             message: `Expected value to exist, but it was <${value}>`,
             name: ASSERTION_ERROR
           });
-          assert.deepStrictEqual(test.not.toExist(), test.not);
+          assert.deepStrictEqual(test.not.toExist(), test);
         });
       });
     });
@@ -147,7 +167,7 @@ describe("[Unit] Assertion.test.ts", () => {
           message: "Expected <foo> to be null",
           name: ASSERTION_ERROR
         });
-        assert.deepStrictEqual(test.not.toBeNull(), test.not);
+        assert.deepStrictEqual(test.not.toBeNull(), test);
       });
     });
   });
@@ -173,7 +193,7 @@ describe("[Unit] Assertion.test.ts", () => {
           message: "Expected the value to be present",
           name: ASSERTION_ERROR
         });
-        assert.deepStrictEqual(test.not.toBePresent(), test.not);
+        assert.deepStrictEqual(test.not.toBePresent(), test);
       });
     });
   });
@@ -202,7 +222,7 @@ describe("[Unit] Assertion.test.ts", () => {
             message: `Expected <${value}> to be a truthy value`,
             name: ASSERTION_ERROR
           });
-          assert.deepStrictEqual(test.not.toBeTruthy(), test.not);
+          assert.deepStrictEqual(test.not.toBeTruthy(), test);
         });
       });
     });
@@ -232,7 +252,7 @@ describe("[Unit] Assertion.test.ts", () => {
             message: `Expected <${value}> to be a falsy value`,
             name: ASSERTION_ERROR
           });
-          assert.deepStrictEqual(test.not.toBeFalsy(), test.not);
+          assert.deepStrictEqual(test.not.toBeFalsy(), test);
         });
       });
     });
@@ -280,7 +300,7 @@ describe("[Unit] Assertion.test.ts", () => {
             message: "Expected both values to be deep equal",
             name: ASSERTION_ERROR
           });
-          assert.deepStrictEqual(test.not.toBeEqual(expected), test.not);
+          assert.deepStrictEqual(test.not.toBeEqual(expected), test);
         });
       });
     });
@@ -326,7 +346,7 @@ describe("[Unit] Assertion.test.ts", () => {
             message: "Expected both values to be similar",
             name: ASSERTION_ERROR
           });
-          assert.deepStrictEqual(test.not.toBeSimilar(expected), test.not);
+          assert.deepStrictEqual(test.not.toBeSimilar(expected), test);
         });
       });
     });
@@ -366,7 +386,7 @@ describe("[Unit] Assertion.test.ts", () => {
             message: "Expected both values to be the same",
             name: ASSERTION_ERROR
           });
-          assert.deepStrictEqual(test.not.toBeSame(expected), test.not);
+          assert.deepStrictEqual(test.not.toBeSame(expected), test);
         });
       });
     });

--- a/test/lib/BooleanAssertion.test.ts
+++ b/test/lib/BooleanAssertion.test.ts
@@ -24,7 +24,7 @@ describe("[Unit] BooleanAssertion.test.ts", () => {
           message: "Expected value to be true",
           name: "AssertionError"
         });
-        assert.deepStrictEqual(test.not.toBeTrue(), test.not);
+        assert.deepStrictEqual(test.not.toBeTrue(), test);
       });
     });
   });
@@ -50,7 +50,7 @@ describe("[Unit] BooleanAssertion.test.ts", () => {
           message: "Expected value to be false",
           name: "AssertionError"
         });
-        assert.deepStrictEqual(test.not.toBeFalse(), test.not);
+        assert.deepStrictEqual(test.not.toBeFalse(), test);
       });
     });
   });

--- a/test/lib/StringAssertion.test.ts
+++ b/test/lib/StringAssertion.test.ts
@@ -26,7 +26,7 @@ describe("[Unit] StringAssertion.test.ts", () => {
           message: "Expected <Hello World!> to be empty",
           name: ASSERTION_ERROR
         });
-        assert.deepStrictEqual(test.not.toBeEmpty(), test.not);
+        assert.deepStrictEqual(test.not.toBeEmpty(), test);
       });
     });
   });
@@ -51,7 +51,7 @@ describe("[Unit] StringAssertion.test.ts", () => {
           message: "Expected <  x y z  > to be blank",
           name: ASSERTION_ERROR
         });
-        assert.deepStrictEqual(test.not.toBeBlank(), test.not);
+        assert.deepStrictEqual(test.not.toBeBlank(), test);
       });
     });
   });
@@ -77,7 +77,7 @@ describe("[Unit] StringAssertion.test.ts", () => {
           message: "Expected both string to be equal ignoring case",
           name: ASSERTION_ERROR
         });
-        assert.deepStrictEqual(test.not.toBeEqualIgnoringCase("mIxEd sTrInG"), test.not);
+        assert.deepStrictEqual(test.not.toBeEqualIgnoringCase("mIxEd sTrInG"), test);
       });
     });
   });
@@ -112,7 +112,7 @@ describe("[Unit] StringAssertion.test.ts", () => {
           message: "Expected <Hello World!> to contain <Bye>",
           name: ASSERTION_ERROR
         });
-        assert.deepStrictEqual(test.not.toContain("Bye"), test.not);
+        assert.deepStrictEqual(test.not.toContain("Bye"), test);
       });
     });
   });
@@ -138,7 +138,7 @@ describe("[Unit] StringAssertion.test.ts", () => {
           message: "Expected <Hello World!> to contain <bye> (ignoring case)",
           name: ASSERTION_ERROR
         });
-        assert.deepStrictEqual(test.not.toContainIgnoringCase("bye"), test.not);
+        assert.deepStrictEqual(test.not.toContainIgnoringCase("bye"), test);
       });
     });
   });
@@ -173,7 +173,7 @@ describe("[Unit] StringAssertion.test.ts", () => {
           message: "Expected <Hello World!> to start with <Goodbye>",
           name: ASSERTION_ERROR
         });
-        assert.deepStrictEqual(test.not.toStartWith("Goodbye"), test.not);
+        assert.deepStrictEqual(test.not.toStartWith("Goodbye"), test);
       });
     });
   });
@@ -199,7 +199,7 @@ describe("[Unit] StringAssertion.test.ts", () => {
           message: "Expected <Hello World!> to end with <Moon!>",
           name: ASSERTION_ERROR
         });
-        assert.deepStrictEqual(test.not.toStartWith("Moon!"), test.not);
+        assert.deepStrictEqual(test.not.toStartWith("Moon!"), test);
       });
     });
   });
@@ -225,7 +225,7 @@ describe("[Unit] StringAssertion.test.ts", () => {
           message: "Expected <1234567890x> to match the regular expression </^[0-9]+$/>",
           name: ASSERTION_ERROR
         });
-        assert.deepStrictEqual(test.not.toMatchRegex(/^[0-9]+$/), test.not);
+        assert.deepStrictEqual(test.not.toMatchRegex(/^[0-9]+$/), test);
       });
     });
   });


### PR DESCRIPTION
Fix the fluent API after a negation is used. This means that after a `.not` assertion is used, the next assertion should not be negated, so user may be able to choose to negate or not negate following fluent assertions.