### PR TITLE
[Assertion] Add `.asType` with factories

### DIFF
--- a/src/lib/helpers/TypeFactories.ts
+++ b/src/lib/helpers/TypeFactories.ts
@@ -1,0 +1,69 @@
+import { Assertion } from "../Assertion";
+import { BooleanAssertion } from "../BooleanAssertion";
+import { DateAssertion } from "../DateAssertion";
+import { AnyFunction, FunctionAssertion } from "../FunctionAssertion";
+import { NumberAssertion } from "../NumberAssertion";
+import { JSObject, ObjectAssertion } from "../ObjectAssertion";
+import { StringAssertion } from "../StringAssertion";
+
+import { isJSObject } from "./guards";
+
+type AssertionFactory<S, A extends Assertion<S>> = new(actual: S) => A;
+
+export interface TypeFactory<S, A extends Assertion<S>> {
+  Factory: AssertionFactory<S, A>;
+  predicate(value: unknown): value is S;
+  typeName: string;
+}
+
+interface StaticTypeFactories {
+  Boolean: TypeFactory<boolean, BooleanAssertion>;
+  Date: TypeFactory<Date, DateAssertion>;
+  Function: TypeFactory<AnyFunction, FunctionAssertion<AnyFunction>>;
+  Number: TypeFactory<number, NumberAssertion>;
+  String: TypeFactory<string, StringAssertion>;
+  instanceOf<T extends Function>(type: T): TypeFactory<T, Assertion<T>>; // tslint:disable-line: ban-types
+  object<T extends JSObject>(): TypeFactory<T, ObjectAssertion<T>>;
+}
+
+export const TypeFactories: Readonly<StaticTypeFactories> = {
+  Boolean: {
+    Factory: BooleanAssertion,
+    predicate: (value): value is boolean => typeof value === "boolean",
+    typeName: "boolean"
+  },
+  Date: {
+    Factory: DateAssertion,
+    predicate: (value): value is Date => value instanceof Date,
+    typeName: Date.name
+  },
+  Function: {
+    Factory: FunctionAssertion,
+    predicate: (value): value is AnyFunction => typeof value === "function",
+    typeName: "function"
+  },
+  Number: {
+    Factory: NumberAssertion,
+    predicate: (value): value is number => typeof value === "number",
+    typeName: "number"
+  },
+  String: {
+    Factory: StringAssertion,
+    predicate: (value): value is string => typeof value === "string",
+    typeName: "string"
+  },
+  instanceOf(type) {
+    return {
+      Factory: Assertion,
+      predicate: (value): value is typeof type => value instanceof type,
+      typeName: type.name
+    };
+  },
+  object<T extends JSObject>() {
+    return {
+      Factory: ObjectAssertion,
+      predicate: (value): value is T => isJSObject(value),
+      typeName: "object"
+    };
+  }
+};

--- a/test/lib/Assertion.test.ts
+++ b/test/lib/Assertion.test.ts
@@ -1,6 +1,8 @@
 import assert, { AssertionError } from "assert";
 
 import { Assertion } from "../../src/lib/Assertion";
+import { TypeFactories } from "../../src/lib/helpers/TypeFactories";
+import { StringAssertion } from "../../src/lib/StringAssertion";
 
 const HERO = {
   name: "Batman",
@@ -390,6 +392,35 @@ describe("[Unit] Assertion.test.ts", () => {
             name: AssertionError.name
           });
           assert.deepStrictEqual(test.not.toBeSame(expected), test);
+        });
+      });
+    });
+  });
+
+  describe(".asType", () => {
+    context("when the type predicate is true", () => {
+      it("returns a new instance of the assertion passed to the type factory", () => {
+        const test = new Assertion("foo");
+
+        assert.deepStrictEqual(test.asType(TypeFactories.String), new StringAssertion("foo"));
+        assert.throws(() => test.not.asType(TypeFactories.String), {
+          message: "Unsupported operation. The `.not` modifier is not allowed on `.asType(..)` method",
+          name: Error.name
+        });
+      });
+    });
+
+    context("when the predicate is false", () => {
+      it("throws an assertion error", () => {
+        const test = new Assertion("foo");
+
+        assert.throws(() => test.asType(TypeFactories.Boolean), {
+          message: 'Expected <foo> to be of type "boolean"',
+          name: AssertionError.name
+        });
+        assert.throws(() => test.not.asType(TypeFactories.Boolean), {
+          message: "Unsupported operation. The `.not` modifier is not allowed on `.asType(..)` method",
+          name: Error.name
         });
       });
     });

--- a/test/lib/helpers/TypeFactories.test.ts
+++ b/test/lib/helpers/TypeFactories.test.ts
@@ -1,0 +1,137 @@
+import assert from "assert";
+
+import { TypeFactories } from "../../../src/lib/helpers/TypeFactories";
+
+describe("[Unit] TypeFactories.test.ts", () => {
+  describe(".predicate", () => {
+    describe("#Boolean", () => {
+      context("when the value is a boolean", () => {
+        [true, false].forEach(bool => {
+          it(`[${bool}] returns true`, () => {
+            const result = TypeFactories.Boolean.predicate(bool);
+
+            assert.equal(result, true);
+          });
+        });
+      });
+
+      context("when the value is not a boolean", () => {
+        it("returns false", () => {
+          const result = TypeFactories.Boolean.predicate(0);
+
+          assert.equal(result, false);
+        });
+      });
+    });
+
+    describe("#Date", () => {
+      context("when the value is a Date", () => {
+        it("returns true", () => {
+          const result = TypeFactories.Date.predicate(new Date());
+
+          assert.equal(result, true);
+        });
+      });
+
+      context("when the value is not a Date", () => {
+        it("returns false", () => {
+          const result = TypeFactories.Date.predicate("foo");
+
+          assert.equal(result, false);
+        });
+      });
+    });
+
+    describe("#Function", () => {
+      context("when the value is a function", () => {
+        it("returns true", () => {
+          const result = TypeFactories.Function.predicate(() => undefined);
+
+          assert.equal(result, true);
+        });
+      });
+
+      context("when the value is not a function", () => {
+        it("returns false", () => {
+          const result = TypeFactories.Function.predicate({ });
+
+          assert.equal(result, false);
+        });
+      });
+    });
+
+    describe("#Number", () => {
+      context("when the value is a number", () => {
+        [1, -1, NaN, Infinity, -Infinity].forEach(num => {
+          it(`[${num}] returns true`, () => {
+            const result = TypeFactories.Number.predicate(num);
+
+            assert.equal(result, true);
+          });
+        });
+      });
+
+      context("when the value is not a number", () => {
+        it("returns false", () => {
+          const result = TypeFactories.Number.predicate("foo");
+
+          assert.equal(result, false);
+        });
+      });
+    });
+
+    describe("#String", () => {
+      context("when the value is a string", () => {
+        it("returns true", () => {
+          const result = TypeFactories.String.predicate("foo");
+
+          assert.equal(result, true);
+        });
+      });
+
+      context("when the value is not a string", () => {
+        it("returns false", () => {
+          const result = TypeFactories.String.predicate(1);
+
+          assert.equal(result, false);
+        });
+      });
+    });
+
+    describe(".instanceOf", () => {
+      context("when the value is an instance of the passed type", () => {
+        it("returns true", () => {
+          const result = TypeFactories.instanceOf(Error).predicate(Error("foo"));
+
+          assert.equal(result, true);
+        });
+      });
+
+      context("when the value is not an instance of the passed type", () => {
+        it("returns false", () => {
+          const result = TypeFactories.instanceOf(Error).predicate("foo");
+
+          assert.equal(result, false);
+        });
+      });
+    });
+
+    describe(".object", () => {
+      context("when the value is a JS object", () => {
+        it("returns true", () => {
+          const result = TypeFactories.object().predicate({ x: "foo" });
+
+          assert.equal(result, true);
+        });
+      });
+
+      context("when the value is not a JS object", () => {
+        it("returns false", () => {
+          const result = TypeFactories.object().predicate(() => undefined);
+
+          assert.equal(result, false);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Implementation details

This method will allow users to check if a value is of a specific type and then "cast" the assertion into a more specific `Assertion<T>` implementation. It will be most useful in cases were the type of the value under test is `unknown, `any`, or even union of types so we can assert more specifically over one of them.

To allow the assertion and the casting at the same time, this method requires a `TypeFactory` parameter, which is nothing more than a predicate to assert the type and a Factory function for the resulting assertion instance. The benefit of this type is that the generics are correlated, so for instance, if the predicate asserts that the type of the value is a `string`, we must pass an assertion factory that extends from `Assertion<string>`.
```ts
type AssertionFactory<S, A extends Assertion<S>> = new(actual: S) => A;

interface TypeFactory<S, A extends Assertion<S>> {
  Factory: AssertionFactory<S, A>;
  predicate(value: unknown): value is S;
}
```

The use is simple but requires the extra safety of the predicate. So if we want top create an TypeFactory for a `boolean`, for instance, we'd do the following:
```ts
// Keep in mind that BooleanAssertion extends from Assertion<boolean>

const boolFactory: TypeFactory<boolean, BooleanAssertion> = {
  Factory: BooleanAssertion,
  predicate: (value): value is boolean => typeof value === "boolean"
};
```

To reduce the boilerplate, we'll provide with the most common type factories, so usage of this method should look like the following:
```ts
expect(unknownValue)
  .asType(TypeFactories.STRING)
  .startsWith("/api");
```

## Future work

Movin with the plan of making the library as extensible as possible, we need to ensure that the `TypeFactories` singleton can be extended by other packages so they can add their own type factories and keep its the usage transparent and centralized.