### PR TITLE
[ObjectAssertion] Refactor Tests & define JSObject type

### DIFF
--- a/src/lib/ObjectAssertion.ts
+++ b/src/lib/ObjectAssertion.ts
@@ -2,7 +2,12 @@ import { AssertionError } from "assert";
 import { isDeepStrictEqual } from "util";
 
 import { Assertion } from "./Assertion";
-import { JSObject, KeyOf, ValueOf } from "./ObjectAssertion.types";
+
+export type JSObject = Record<keyof any, unknown>;
+
+type Entry<T, K = keyof T> = K extends keyof T
+  ? [K, T[K]]
+  : never;
 
 export class ObjectAssertion<T extends JSObject> extends Assertion<T> {
 
@@ -38,7 +43,7 @@ export class ObjectAssertion<T extends JSObject> extends Assertion<T> {
    * @param key the key that the object should contain
    * @returns the assertion instance
    */
-  public toContainKey(key: KeyOf<T>): this {
+  public toContainKey(key: keyof T): this {
     const error = new AssertionError({
       actual: this.actual,
       message: `Expected the object to contain the provided key <${key}>`
@@ -61,7 +66,7 @@ export class ObjectAssertion<T extends JSObject> extends Assertion<T> {
    * @param keys the keys that the object should contain
    * @returns the assertion instance
    */
-  public toContainAllKeys(keys: KeyOf<T>[]): this {
+  public toContainAllKeys(keys: Array<keyof T>): this {
     const error = new AssertionError({
       actual: this.actual,
       message: `Expected the object to contain all the provided keys <${keys}>`
@@ -84,7 +89,7 @@ export class ObjectAssertion<T extends JSObject> extends Assertion<T> {
    * @param keys the keys that the object may contain
    * @returns the assertion instance
    */
-  public toContainAnyKeys(keys: KeyOf<T>[]): this {
+  public toContainAnyKeys(keys: Array<keyof T>): this {
     const error = new AssertionError({
       actual: this.actual,
       message: `Expected the object to contain at least one of the provided keys <${keys}>`
@@ -107,7 +112,7 @@ export class ObjectAssertion<T extends JSObject> extends Assertion<T> {
    * @param value the property value that the object should contain in any of its keys
    * @returns the assertion instance
    */
-  public toContainValue(value: ValueOf<T>): this {
+  public toContainValue(value: T[keyof T]): this {
     const error = new AssertionError({
       actual: this.actual,
       message: `Expected the object to contain the provided value <${value}>`
@@ -130,7 +135,7 @@ export class ObjectAssertion<T extends JSObject> extends Assertion<T> {
    * @param values the property values that the object should contain
    * @returns the assertion instance
    */
-  public toContainAllValues(values: ValueOf<T>[]): this {
+  public toContainAllValues(values: Array<T[keyof T]>): this {
     const error = new AssertionError({
       actual: this.actual,
       message: `Expected the object to contain all the provided values <${values}>`
@@ -156,7 +161,7 @@ export class ObjectAssertion<T extends JSObject> extends Assertion<T> {
    * @param values the property values that the object should contain
    * @returns the assertion instance
    */
-  public toContainAnyValues(values: ValueOf<T>[]): this {
+  public toContainAnyValues(values: Array<T[keyof T]>): this {
     const error = new AssertionError({
       actual: this.actual,
       message: `Expected the object to contain at least one of the provided values <${values}>`
@@ -182,7 +187,7 @@ export class ObjectAssertion<T extends JSObject> extends Assertion<T> {
    * @param entry the entry that the object should contain
    * @returns the assertion instance
    */
-  public toContainEntry(entry: [KeyOf<T>, ValueOf<T>]): this {
+  public toContainEntry(entry: Entry<T>): this {
     const error = new AssertionError({
       actual: this.actual,
       message: `Expected the object to contain the provided entry <${JSON.stringify(entry)}>`
@@ -207,7 +212,7 @@ export class ObjectAssertion<T extends JSObject> extends Assertion<T> {
    * @param entries the entries that the object should contain
    * @returns the assertion instance
    */
-  public toContainAllEntries(entries: [KeyOf<T>, ValueOf<T>][]): this {
+  public toContainAllEntries(...entries: Array<Entry<T>>): this {
     const error = new AssertionError({
       actual: this.actual,
       message: `Expected the object to contain all the provided entries <${JSON.stringify(entries)}>`
@@ -234,7 +239,7 @@ export class ObjectAssertion<T extends JSObject> extends Assertion<T> {
    * @param entries the entries that the object should contain
    * @returns the assertion instance
    */
-  public toContainAnyEntries(entries: [KeyOf<T>, ValueOf<T>][]): this {
+  public toContainAnyEntries(...entries: Array<Entry<T>>): this {
     const error = new AssertionError({
       actual: this.actual,
       message: `Expected the object to contain at least one of the provided entries <${JSON.stringify(entries)}>`

--- a/src/lib/ObjectAssertion.types.ts
+++ b/src/lib/ObjectAssertion.types.ts
@@ -1,9 +1,0 @@
-export type KeyOf<T extends object> = keyof T extends never
-  ? string | number | symbol
-  : keyof T;
-
-export type ValueOf<T extends object> = keyof T extends never
-  ? any
-  : T[keyof T];
-
-export type JSObject = Record<keyof any, unknown>;

--- a/src/lib/expect.ts
+++ b/src/lib/expect.ts
@@ -4,7 +4,7 @@ import { DateAssertion } from "./DateAssertion";
 import { AnyFunction, FunctionAssertion } from "./FunctionAssertion";
 import { isAnyFunction, isJSObject, isPromise } from "./helpers/guards";
 import { NumberAssertion } from "./NumberAssertion";
-import { ObjectAssertion } from "./ObjectAssertion";
+import { JSObject, ObjectAssertion } from "./ObjectAssertion";
 import { PromiseAssertion } from "./PromiseAssertion";
 import { StringAssertion } from "./StringAssertion";
 
@@ -16,7 +16,7 @@ export function expect<T extends string>(actual: T): StringAssertion;
 export function expect<T extends Date>(actual: T): DateAssertion;
 export function expect<T extends Promise<any>>(actual: T): PromiseAssertion<PromiseType<T>>;
 export function expect<T extends AnyFunction>(actual: T): FunctionAssertion<T>;
-export function expect<T extends object>(actual: T): ObjectAssertion<T>;
+export function expect<T extends JSObject>(actual: T): ObjectAssertion<T>;
 export function expect<T>(actual: T): Assertion<T>;
 export function expect<T>(actual: T) {
   switch (typeof actual) {

--- a/src/lib/helpers/guards.ts
+++ b/src/lib/helpers/guards.ts
@@ -6,7 +6,7 @@ import {
   LowInclusiveBetweenOptions
 } from "../NumberAssertion";
 
-export function isJSObject<T>(value: T): value is T & object {
+export function isJSObject<T>(value: T): value is { [K in keyof T]: T[K] } {
   return value !== null
     && typeof value === "object"
     && typeof value !== "function";

--- a/test/lib/ObjectAssertion.test.ts
+++ b/test/lib/ObjectAssertion.test.ts
@@ -1,32 +1,21 @@
 import assert, { AssertionError } from "assert";
 
 import { ObjectAssertion } from "../../src/lib/ObjectAssertion";
-import { JSObject } from "../../src/lib/ObjectAssertion.types";
 
-type Entry = [string | number | symbol, number | object | string];
+type Entry = ["myKey", number] | [2, { innerObjKey: number; message: string; }] | [string, boolean];
 
-const TEST_OBJ: JSObject = {
+const RECORD: Record<string, boolean> = {
+  "falsy": false,
+  "truthy": true
+};
+
+const TEST_OBJ = {
   myKey: 0,
   2: {
     innerObjKey: 1,
     message: "inner value"
   }
 };
-
-const ENTRIES: Entry[] = [
-  ["myKey", 0],
-  [2, { innerObjKey: 1, message: "inner value" }]
-];
-
-const WRONG_ENTRIES: Entry[] = [
-  ["myKey", 4],
-  [3, { innerObjKey: 4, message: "inner wrong value" }]
-];
-
-const SOME_ENTRIES: Entry[] = [
-  ["myKey", 0],
-  [3, { innerObjKey: 4, message: "inner wrong value" }]
-];
 
 describe("[Unit] ObjectAssertion.test.ts", () => {
   describe(".toBeEmpty", () => {
@@ -57,30 +46,28 @@ describe("[Unit] ObjectAssertion.test.ts", () => {
 
   describe(".toContainKey", () => {
     context("when the object contains the provided key", () => {
-      [2, "myKey"].forEach(key => {
-        it(`[${typeof key} key] returns the assertion instance`, () => {
-          const test = new ObjectAssertion(TEST_OBJ);
+      it("returns the assertion instance", () => {
+        const key = "myKey";
+        const test = new ObjectAssertion(TEST_OBJ);
 
-          assert.deepStrictEqual(test.toContainKey(key), test);
-          assert.throws(() => test.not.toContainKey(key), {
-            message: `Expected the object NOT to contain the provided key <${key}>`,
-            name: AssertionError.name
-          });
+        assert.deepStrictEqual(test.toContainKey(key), test);
+        assert.throws(() => test.not.toContainKey(key), {
+          message: `Expected the object NOT to contain the provided key <${key}>`,
+          name: AssertionError.name
         });
       });
     });
 
     context("when the object does NOT contain the provided key", () => {
-      [3, "myWrongKey"].forEach(wrongKey => {
-        it(`[${typeof wrongKey} key] throws an assertion error`, () => {
-          const test = new ObjectAssertion(TEST_OBJ);
+      it("throws an assertion error", () => {
+        const wrongKey = "wrongKey";
+        const test = new ObjectAssertion(RECORD);
 
-          assert.throws(() => test.toContainKey(wrongKey), {
-            message: `Expected the object to contain the provided key <${wrongKey}>`,
-            name: AssertionError.name
-          });
-          assert.deepStrictEqual(test.not.toContainKey(wrongKey), test);
+        assert.throws(() => test.toContainKey(wrongKey), {
+          message: `Expected the object to contain the provided key <${wrongKey}>`,
+          name: AssertionError.name
         });
+        assert.deepStrictEqual(test.not.toContainKey(wrongKey), test);
       });
     });
   });
@@ -88,12 +75,12 @@ describe("[Unit] ObjectAssertion.test.ts", () => {
   describe(".toContainAllKeys", () => {
     context("when the object contains all the provided keys", () => {
       it("returns the assertion instance", () => {
-        const myKeys = ["myKey", 2];
+        const keys: Array<"myKey" | 2> = ["myKey", 2];
         const test = new ObjectAssertion(TEST_OBJ);
 
-        assert.deepStrictEqual(test.toContainAllKeys(myKeys), test);
-        assert.throws(() => test.not.toContainAllKeys(myKeys), {
-          message: `Expected the object NOT to contain all the provided keys <${myKeys}>`,
+        assert.deepStrictEqual(test.toContainAllKeys(["myKey", 2]), test);
+        assert.throws(() => test.not.toContainAllKeys(keys), {
+          message: `Expected the object NOT to contain all the provided keys <${keys}>`,
           name: AssertionError.name
         });
       });
@@ -101,17 +88,14 @@ describe("[Unit] ObjectAssertion.test.ts", () => {
 
     context("when the object does NOT contain all the provided keys", () => {
       it("throws an assertion error", () => {
-        const someKeys = ["myKey", 3];
-        const test = new ObjectAssertion(TEST_OBJ);
+        const someKeys = ["truthy", "wrongKey"];
+        const test = new ObjectAssertion(RECORD);
 
         assert.throws(() => test.toContainAllKeys(someKeys), {
           message: `Expected the object to contain all the provided keys <${someKeys}>`,
           name: AssertionError.name
         });
-        assert.deepStrictEqual(
-          test.not.toContainAllKeys(someKeys),
-          test
-        );
+        assert.deepStrictEqual(test.not.toContainAllKeys(someKeys), test);
       });
     });
   });
@@ -119,8 +103,8 @@ describe("[Unit] ObjectAssertion.test.ts", () => {
   describe(".toContainAnyKeys", () => {
     context("when the object contains at least one of the the provided keys", () => {
       it("returns the assertion instance", () => {
-        const someKeys = ["myKey", "objKey", 4, "randomKey"];
-        const test = new ObjectAssertion(TEST_OBJ);
+        const someKeys = ["truthy", "wrongKey"];
+        const test = new ObjectAssertion(RECORD);
 
         assert.deepStrictEqual(test.toContainAnyKeys(someKeys), test);
         assert.throws(() => test.not.toContainAnyKeys(someKeys), {
@@ -132,8 +116,8 @@ describe("[Unit] ObjectAssertion.test.ts", () => {
 
     context("when the object does NOT contain any of the provided keys", () => {
       it("throws an assertion error", () => {
-        const wrongKeys = ["notMyKey", 3, "randomKey"];
-        const test = new ObjectAssertion(TEST_OBJ);
+        const wrongKeys = ["wrongKey", "randomKey"];
+        const test = new ObjectAssertion(RECORD);
 
         assert.throws(() => test.toContainAnyKeys(wrongKeys), {
           message: `Expected the object to contain at least one of the provided keys <${wrongKeys}>`,
@@ -146,39 +130,29 @@ describe("[Unit] ObjectAssertion.test.ts", () => {
 
   describe(".toContainValue", () => {
     context("when the object contains the provided value", () => {
-      [
-        0,
-        { innerObjKey: 1, message: "inner value" }
-      ]
-        .forEach(value => {
-          it(`[${typeof value} value] returns the assertion instance`, () => {
-            const test = new ObjectAssertion(TEST_OBJ);
+      it("returns the assertion instance", () => {
+        const value = { innerObjKey: 1, message: "inner value" };
+        const test = new ObjectAssertion(TEST_OBJ);
 
-            assert.deepStrictEqual(test.toContainValue(value), test);
-            assert.throws(() => test.not.toContainValue(value), {
-              message: `Expected the object NOT to contain the provided value <${value}>`,
-              name: AssertionError.name
-            });
-          });
+        assert.deepStrictEqual(test.toContainValue(value), test);
+        assert.throws(() => test.not.toContainValue(value), {
+          message: `Expected the object NOT to contain the provided value <${value}>`,
+          name: AssertionError.name
         });
+      });
     });
 
     context("when the object does NOT contain the provided value", () => {
-      [
-        1,
-        { innerObjKey: 1, message: "inner wrong value" }
-      ]
-        .forEach(value => {
-          it(`[${typeof value} value] throws an assertion error`, () => {
-            const test = new ObjectAssertion(TEST_OBJ);
+      it("throws an assertion error", () => {
+        const wrongValue = 4;
+        const test = new ObjectAssertion(TEST_OBJ);
 
-            assert.throws(() => test.toContainValue(value), {
-              message: `Expected the object to contain the provided value <${value}>`,
-              name: AssertionError.name
-            });
-            assert.deepStrictEqual(test.not.toContainValue(value), test);
-          });
+        assert.throws(() => test.toContainValue(wrongValue), {
+          message: `Expected the object to contain the provided value <${wrongValue}>`,
+          name: AssertionError.name
         });
+        assert.deepStrictEqual(test.not.toContainValue(wrongValue), test);
+      });
     });
   });
 
@@ -240,30 +214,28 @@ describe("[Unit] ObjectAssertion.test.ts", () => {
 
   describe(".toContainEntry", () => {
     context("when the object contains the provided entry", () => {
-      ENTRIES.forEach(entry => {
-        it(`[${typeof entry[0]}, ${typeof entry[1]}] entry returns the assertion instance`, () => {
-          const test = new ObjectAssertion(TEST_OBJ);
+      it("returns the assertion instance", () => {
+        const entry: Entry = ["myKey", 0];
+        const test = new ObjectAssertion(TEST_OBJ);
 
-          assert.deepStrictEqual(test.toContainEntry(entry), test);
-          assert.throws(() => test.not.toContainEntry(entry), {
-            message: `Expected the object NOT to contain the provided entry <${JSON.stringify(entry)}>`,
-            name: AssertionError.name
-          });
+        assert.deepStrictEqual(test.toContainEntry(entry), test);
+        assert.throws(() => test.not.toContainEntry(entry), {
+          message: `Expected the object NOT to contain the provided entry <${JSON.stringify(entry)}>`,
+          name: AssertionError.name
         });
       });
     });
 
     context("when the object does NOT contain the provided entry", () => {
-      WRONG_ENTRIES.forEach(wrongEntry => {
-        it(`[${typeof wrongEntry[0]}, ${typeof wrongEntry[1]}] entry throws an assertion error`, () => {
-          const test = new ObjectAssertion(TEST_OBJ);
+      it("throws an assertion error", () => {
+        const wrongEntry: Entry = ["myKey", 2];
+        const test = new ObjectAssertion(TEST_OBJ);
 
-          assert.throws(() => test.toContainEntry(wrongEntry), {
-            message: `Expected the object to contain the provided entry <${JSON.stringify(wrongEntry)}>`,
-            name: AssertionError.name
-          });
-          assert.deepStrictEqual(test.not.toContainEntry(wrongEntry), test);
+        assert.throws(() => test.toContainEntry(wrongEntry), {
+          message: `Expected the object to contain the provided entry <${JSON.stringify(wrongEntry)}>`,
+          name: AssertionError.name
         });
+        assert.deepStrictEqual(test.not.toContainEntry(wrongEntry), test);
       });
     });
   });
@@ -271,11 +243,13 @@ describe("[Unit] ObjectAssertion.test.ts", () => {
   describe(".toContainAllEntries", () => {
     context("when the object contains all the provided entries", () => {
       it("returns the assertion instance", () => {
+        const entry1: Entry = ["myKey", 0];
+        const entry2: Entry = [2, { innerObjKey: 1, message: "inner value" }];
         const test = new ObjectAssertion(TEST_OBJ);
 
-        assert.deepStrictEqual(test.toContainAllEntries(ENTRIES), test);
-        assert.throws(() => test.not.toContainAllEntries(ENTRIES), {
-          message: `Expected the object NOT to contain all the provided entries <${JSON.stringify(ENTRIES)}>`,
+        assert.deepStrictEqual(test.toContainAllEntries(entry1, entry2), test);
+        assert.throws(() => test.not.toContainAllEntries(entry1, entry2), {
+          message: `Expected the object NOT to contain all the provided entries <${JSON.stringify([entry1, entry2])}>`,
           name: AssertionError.name
         });
       });
@@ -283,13 +257,15 @@ describe("[Unit] ObjectAssertion.test.ts", () => {
 
     context("when the object does NOT contain all the provided entries", () => {
       it("throws an assertion error", () => {
-        const test = new ObjectAssertion(TEST_OBJ);
+        const entry: Entry = ["truthy", true];
+        const wrongEntry: Entry = ["wrongKey", false];
+        const test = new ObjectAssertion(RECORD);
 
-        assert.throws(() => test.toContainAllEntries(SOME_ENTRIES), {
-          message: `Expected the object to contain all the provided entries <${JSON.stringify(SOME_ENTRIES)}>`,
+        assert.throws(() => test.toContainAllEntries(entry, wrongEntry), {
+          message: `Expected the object to contain all the provided entries <${JSON.stringify([entry, wrongEntry])}>`,
           name: AssertionError.name
         });
-        assert.deepStrictEqual(test.not.toContainAllEntries(SOME_ENTRIES), test);
+        assert.deepStrictEqual(test.not.toContainAllEntries(entry, wrongEntry), test);
       });
     });
   });
@@ -297,11 +273,13 @@ describe("[Unit] ObjectAssertion.test.ts", () => {
   describe(".toContainAnyEntries", () => {
     context("when the object contains at least one of the provided entries", () => {
       it("returns the assertion instance", () => {
-        const test = new ObjectAssertion(TEST_OBJ);
+        const entry: Entry = ["truthy", true];
+        const wrongEntry: Entry = ["wrongKey", false];
+        const test = new ObjectAssertion(RECORD);
 
-        assert.deepStrictEqual(test.toContainAnyEntries(SOME_ENTRIES), test);
-        assert.throws(() => test.not.toContainAnyEntries(SOME_ENTRIES), {
-          message: `Expected the object NOT to contain any of the provided entries <${JSON.stringify(SOME_ENTRIES)}>`,
+        assert.deepStrictEqual(test.toContainAnyEntries(entry, wrongEntry), test);
+        assert.throws(() => test.not.toContainAnyEntries(entry, wrongEntry), {
+          message: `Expected the object NOT to contain any of the provided entries <${JSON.stringify([entry, wrongEntry])}>`,
           name: AssertionError.name
         });
       });
@@ -309,13 +287,15 @@ describe("[Unit] ObjectAssertion.test.ts", () => {
 
     context("when the object does NOT contain any of the provided entries", () => {
       it("throws an assertion error", () => {
-        const test = new ObjectAssertion(TEST_OBJ);
+        const wrongEntry1: Entry = ["wrongKey", false];
+        const wrongEntry2: Entry = ["truthy", false];
+        const test = new ObjectAssertion(RECORD);
 
-        assert.throws(() => test.toContainAnyEntries(WRONG_ENTRIES), {
-          message: `Expected the object to contain at least one of the provided entries <${JSON.stringify(WRONG_ENTRIES)}>`,
+        assert.throws(() => test.toContainAnyEntries(wrongEntry1, wrongEntry2), {
+          message: `Expected the object to contain at least one of the provided entries <${JSON.stringify([wrongEntry1, wrongEntry2])}>`,
           name: AssertionError.name
         });
-        assert.deepStrictEqual(test.not.toContainAnyEntries(WRONG_ENTRIES), test);
+        assert.deepStrictEqual(test.not.toContainAnyEntries(wrongEntry1, wrongEntry2), test);
       });
     });
   });


### PR DESCRIPTION
## Description
It refactors the redundancy in Object Assertion tests.
It defines the JSObject type that is more specific than `object` type used or the Object Assertion.