### PR TITLE
docs(gh-pages): Standard documentation and GH pages setup

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,67 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: ["release"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install Yarn
+        run: npm install -g yarn
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: .yarn/cache
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build API Reference
+        run: yarn pages
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v1
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Stack Builders
+Copyright (c) 2022 Stack Builders Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,38 +1,60 @@
-# AssertiveTS
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-6-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
-A type-safe fluent assertion library inspired by [Jest](https://jestjs.io/docs/expect) assertions and the popular [AssertJ](https://assertj.github.io/doc/).
+# AssertiveTS
+
+A type-safe fluent assertion library written in TypeScript and inspired by [Jest](https://jestjs.io/docs/expect) assertions and the popular [AssertJ](https://assertj.github.io/doc/).
+
+This library is designed to work in the browser and in Node.js. It ships with a rich set of expressive and flexible matchers that allows chaining multiple assertions. AssertiveTS is framework agnostic and should be used with a test framework such as [Jest](/docs/jest-tutorial.md), [Mocha](/docs/mocha-tutorial.md), or Ava.
+
+## Type-safe library
+
+A distinctive feature of AssertiveTS with other assertion libraries is that it leverages the TypeScript compiler to avoid type coercions and mismatches. It also infers the static type of the value you want to assert and provides you with intelligent matcher completion and signature help so that you can write code more quickly and correctly.
+
+### Features
+
+- Type safety and intelligent matcher completion 
+- Rich set of expressive and flexible matchers
+- Concise, chainable interface inspired by AssertJ
+- Works with any test runner and framework such as [Jest](/docs/jest-tutorial.md), [Mocha](/docs/mocha-tutorial.md), or Ava
+- Well tested: more than 300 tests!
 
 ## Install
-```
+
+```sh
 npm install --save-dev @stackbuilders/assertive-ts
 ```
+
 Or:
-```
+
+```sh
 yarn add --dev @stackbuilders/assertive-ts
 ```
 
 ## Usage
 
 Import the library in your test script:
-```typescript
+
+```ts
 import { expect } from "@stackbuilders/assertive-ts"
 ```
 
 Use the `expect` function along with a "matcher" function on the value you want to assert:
-```typescript
+
+```ts
 expect(sum(1, 2)).toBeEqual(3);
 ```
 
 To assert the opposite, just add `.not` before a matcher:
-```typescript
+
+```ts
 expect(sum(1, 2)).not.toBeNull();
 ```
 
 With `assertive-ts` you can use **fluent assertions**, which means you can chain multiple matcher functions to the same value under test:
-```typescript
+
+```ts
 expect("assertive-ts is awesome!")
   .toStartWith("assertive-ts")
   .not.toContain("unsafe")
@@ -40,7 +62,8 @@ expect("assertive-ts is awesome!")
 ```
 
 The matcher functions depend on the type of the value on the `expect`. If you're using TypeScript, the compiler will let you know if something is not available for that assertion:
-```typescript
+
+```ts
 // Boolean assertion
 expect(isEven(2)).toBeTrue();
 
@@ -54,7 +77,7 @@ expect(14).toEndWith("4");
            ^ ? type error: `toEndWith` does not exist in `NumberAssertion`
 ```
 
-For a list of all matchers and extended documentation, please refer to the API documentation.
+For a list of all matchers and extended documentation, please refer to the [API documentation](https://stackbuilders.github.io/assertive-ts/docs/build/).
 
 ## Test Runner Integration
 
@@ -62,7 +85,8 @@ For a list of all matchers and extended documentation, please refer to the API d
 - [Mocha Integration](docs/mocha-tutorial.md)
 
 ## API Reference
-You can find the full API reference [here](/docs/pages/index.html)
+
+You can find the full API reference [here](https://stackbuilders.github.io/assertive-ts/docs/build/)
 
 ## Contributors ✨
 
@@ -91,4 +115,13 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 
 ## License
 
-[MIT License](https://github.com/stackbuilders/assertive-ts/blob/master/LICENSE)
+MIT, see [the LICENSE file](LICENSE).
+
+## Contributing
+
+Do you want to contribute to this project? Please take a look at our [contributing guideline](/docs/CONTRIBUTING.md) to know how you can help us build it.
+
+---
+<img src="https://www.stackbuilders.com/media/images/Sb-supports.original.png" alt="Stack Builders" width="50%" />
+
+[Check out our libraries](https://github.com/stackbuilders/) | [Join our team](https://www.stackbuilders.com/join-us/)

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,8 @@
+remote_theme: chrisrhymes/bulma-clean-theme
+
+defaults:
+  - scope:
+      path: ""
+    values:
+      title: AssertiveTS
+      subtitle: A type-safe fluent assertion library

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,35 @@
+# Code of conduct
+
+## Purpose
+The primary goal of this Code of Conduct is to enable an open and welcoming environment. We pledge to making participation in our project a harassment-free experience for everyone, regardless of gender, sexual
+orientation, ability, ethnicity, socioeconomic status, and religion (or lack thereof).
+
+## General recommendations
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Maintainer responsibilities
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [community@stackbuilders.com](mailto:community@stackbuilders.com). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+Thank you for your interest in contributing to this Stack Builders' library. To contribute, please take our [Code of Conduct](CODE_OF_CONDUCT.md) into account, along with the following recommendations:
+
+- When submitting contributions to this repository, please make sure to discuss with the maintainer(s) the change you want to make. You can do this through an issue, or by sending an email to [community@stackbuilders.com](mailto:community@stackbuilders.com)
+
+- Once the change has been discussed with the maintainer(s), feel free to open a Pull Request. Please include a link to the issue you're trying to solve, or a quick summary of the discussed changes.
+
+- If adding any new features that you think should be considered in the README file, please add that information in your Pull Request.
+
+- Once you get an approval from any of the maintainers, please merge your Pull Request. Keep in mind that some of our Stack Builders repositories use CI/CD pipelines, so you will need to pass all of the required checks before merging.
+
+## Getting help
+Contact any of our current maintainers, or send us an email at [community@stackbuilders.com](mailto:community@stackbuilders.com) for more information. Thank you for contributing!

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "ts-node": "^10.9.1",
     "tslint": "^6.1.3",
     "typedoc": "^0.23.9",
+    "typedoc-plugin-markdown": "^3.13.4",
     "typedoc-plugin-merge-modules": "^4.0.1",
-    "typedoc-theme-hierarchy": "^3.0.0",
     "typescript": "^4.7.4"
   },
   "packageManager": "yarn@3.2.2"

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,19 +1,21 @@
 {
-  "cleanOutputDir": false,
+  "$schema": "https://typedoc.org/schema.json",
+  "cleanOutputDir": true,
   "entryPoints": ["src/lib"],
   "entryPointStrategy": "expand",
-  "githubPages": true,
-  "includeVersion": true,
+  "gitRevision": "release",
+  "githubPages": false,
+  "hideGenerator": true,
+  "includeVersion": false,
   "mergeModulesMergeMode": "project",
   "mergeModulesRenameDefaults": true,
-  "name": "assertive-ts",
+  "name": "AssertiveTS - API Reference",
   "out": "docs/build",
   "plugin": [
-    "typedoc-theme-hierarchy",
+    "typedoc-plugin-markdown",
     "typedoc-plugin-merge-modules"
   ],
   "readme": "none",
-  "theme": "hierarchy",
   "visibilityFilters": {
     "@alpha": false,
     "@beta": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -404,8 +404,8 @@ __metadata:
     ts-node: ^10.9.1
     tslint: ^6.1.3
     typedoc: ^0.23.9
+    typedoc-plugin-markdown: ^3.13.4
     typedoc-plugin-merge-modules: ^4.0.1
-    typedoc-theme-hierarchy: ^3.0.0
     typescript: ^4.7.4
   languageName: unknown
   linkType: soft
@@ -931,17 +931,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^10.0.0":
-  version: 10.1.0
-  resolution: "fs-extra@npm:10.1.0"
-  dependencies:
-    graceful-fs: ^4.2.0
-    jsonfile: ^6.0.1
-    universalify: ^2.0.0
-  checksum: dc94ab37096f813cc3ca12f0f1b5ad6744dfed9ed21e953d72530d103cea193c2f81584a39e9dee1bea36de5ee66805678c0dddc048e8af1427ac19c00fffc50
-  languageName: node
-  linkType: hard
-
 "fs-minipass@npm:^2.0.0, fs-minipass@npm:^2.1.0":
   version: 2.1.0
   resolution: "fs-minipass@npm:2.1.0"
@@ -1057,10 +1046,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.6":
+"graceful-fs@npm:^4.2.6":
   version: 4.2.10
   resolution: "graceful-fs@npm:4.2.10"
   checksum: 3f109d70ae123951905d85032ebeae3c2a5a7a997430df00ea30df0e3a6c60cf6689b109654d6fdacd28810a053348c4d14642da1d075049e6be1ba5216218da
+  languageName: node
+  linkType: hard
+
+"handlebars@npm:^4.7.7":
+  version: 4.7.7
+  resolution: "handlebars@npm:4.7.7"
+  dependencies:
+    minimist: ^1.2.5
+    neo-async: ^2.6.0
+    source-map: ^0.6.1
+    uglify-js: ^3.1.4
+    wordwrap: ^1.0.0
+  dependenciesMeta:
+    uglify-js:
+      optional: true
+  bin:
+    handlebars: bin/handlebars
+  checksum: 1e79a43f5e18d15742977cb987923eab3e2a8f44f2d9d340982bcb69e1735ed049226e534d7c1074eaddaf37e4fb4f471a8adb71cddd5bc8cf3f894241df5cee
   languageName: node
   linkType: hard
 
@@ -1379,19 +1386,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonfile@npm:^6.0.1":
-  version: 6.1.0
-  resolution: "jsonfile@npm:6.1.0"
-  dependencies:
-    graceful-fs: ^4.1.6
-    universalify: ^2.0.0
-  dependenciesMeta:
-    graceful-fs:
-      optional: true
-  checksum: 7af3b8e1ac8fe7f1eccc6263c6ca14e1966fcbc74b618d3c78a0a2075579487547b94f72b7a1114e844a1e15bb00d440e5d1720bfc4612d790a6f285d5ea8354
-  languageName: node
-  linkType: hard
-
 "just-extend@npm:^4.0.2":
   version: 4.2.1
   resolution: "just-extend@npm:4.2.1"
@@ -1545,7 +1539,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.6":
+"minimist@npm:^1.2.5, minimist@npm:^1.2.6":
   version: 1.2.6
   resolution: "minimist@npm:1.2.6"
   checksum: d15428cd1e11eb14e1233bcfb88ae07ed7a147de251441d61158619dfb32c4d7e9061d09cab4825fdee18ecd6fce323228c8c47b5ba7cd20af378ca4048fb3fb
@@ -1709,6 +1703,13 @@ __metadata:
   version: 0.6.3
   resolution: "negotiator@npm:0.6.3"
   checksum: b8ffeb1e262eff7968fc90a2b6767b04cfd9842582a9d0ece0af7049537266e7b2506dfb1d107a32f06dd849ab2aea834d5830f7f4d0e5cb7d36e1ae55d021d9
+  languageName: node
+  linkType: hard
+
+"neo-async@npm:^2.6.0":
+  version: 2.6.2
+  resolution: "neo-async@npm:2.6.2"
+  checksum: deac9f8d00eda7b2e5cd1b2549e26e10a0faa70adaa6fdadca701cc55f49ee9018e427f424bac0c790b7c7e2d3068db97f3093f1093975f2acb8f8818b936ed9
   languageName: node
   linkType: hard
 
@@ -2224,6 +2225,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "source-map@npm:0.6.1"
+  checksum: 59ce8640cf3f3124f64ac289012c2b8bd377c238e316fb323ea22fbfe83da07d81e000071d7242cad7a23cd91c7de98e4df8830ec3f133cb6133a5f6e9f67bc2
+  languageName: node
+  linkType: hard
+
 "sprintf-js@npm:~1.0.2":
   version: 1.0.3
   resolution: "sprintf-js@npm:1.0.3"
@@ -2451,23 +2459,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typedoc-plugin-markdown@npm:^3.13.4":
+  version: 3.13.4
+  resolution: "typedoc-plugin-markdown@npm:3.13.4"
+  dependencies:
+    handlebars: ^4.7.7
+  peerDependencies:
+    typedoc: ">=0.23.0"
+  checksum: b4edc0147694b8669a05695ef67b6a1f645c10179930fa86759374347f4e8cbb6bd29b58929abce62ab6a3e165de36711ab22eaad240785b1235c06bba4574e4
+  languageName: node
+  linkType: hard
+
 "typedoc-plugin-merge-modules@npm:^4.0.1":
   version: 4.0.1
   resolution: "typedoc-plugin-merge-modules@npm:4.0.1"
   peerDependencies:
     typedoc: 0.23.x
   checksum: a1435c04b5d62f1d422df41dd1a371ab310989bff09d1918a341eede16ca014029051f87ac296cc331091b7fd7001869457499b259e832d9f3c325be696ffab3
-  languageName: node
-  linkType: hard
-
-"typedoc-theme-hierarchy@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "typedoc-theme-hierarchy@npm:3.0.0"
-  dependencies:
-    fs-extra: ^10.0.0
-  peerDependencies:
-    typedoc: ^0.23.6
-  checksum: 70295d5b9ab1ccea319e69d73ebf38d3ea91f88aaa015744200f21734477b8e3295c20eb11da11c5b289e5b358255e3b4658fadf5587917174f53b7f2596cc96
   languageName: node
   linkType: hard
 
@@ -2507,6 +2515,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uglify-js@npm:^3.1.4":
+  version: 3.16.3
+  resolution: "uglify-js@npm:3.16.3"
+  bin:
+    uglifyjs: bin/uglifyjs
+  checksum: 908a6bc877c49ca756bbf50d2ab365ee0315a66af52e14042a5c56077311f3d7c9e028524703c54c8d4b608e3d57346ee0400105acab3c3cded3238513657916
+  languageName: node
+  linkType: hard
+
 "unique-filename@npm:^1.1.1":
   version: 1.1.1
   resolution: "unique-filename@npm:1.1.1"
@@ -2522,13 +2539,6 @@ __metadata:
   dependencies:
     imurmurhash: ^0.1.4
   checksum: 5b6876a645da08d505dedb970d1571f6cebdf87044cb6b740c8dbb24f0d6e1dc8bdbf46825fd09f994d7cf50760e6f6e063cfa197d51c5902c00a861702eb75a
-  languageName: node
-  linkType: hard
-
-"universalify@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "universalify@npm:2.0.0"
-  checksum: 2406a4edf4a8830aa6813278bab1f953a8e40f2f63a37873ffa9a3bc8f9745d06cc8e88f3572cb899b7e509013f7f6fcc3e37e8a6d914167a5381d8440518c44
   languageName: node
   linkType: hard
 
@@ -2601,6 +2611,13 @@ __metadata:
   dependencies:
     string-width: ^1.0.2 || 2 || 3 || 4
   checksum: d5fc37cd561f9daee3c80e03b92ed3e84d80dde3365a8767263d03dacfc8fa06b065ffe1df00d8c2a09f731482fcacae745abfbb478d4af36d0a891fad4834d3
+  languageName: node
+  linkType: hard
+
+"wordwrap@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "wordwrap@npm:1.0.0"
+  checksum: 2a44b2788165d0a3de71fd517d4880a8e20ea3a82c080ce46e294f0b68b69a2e49cff5f99c600e275c698a90d12c5ea32aff06c311f0db2eb3f1201f3e7b2a04
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR changes the documentation to match the Stack Builders OSS standard documents (readme, contributing, code of conduct. license, etc.) It also adds a GitHub Actions workflow to build the API Reference with TypeDoc, and publish it along with the Jekyll static site to GitHub Pages.

The static site will only be generated when changes are pushed to the `release` branch, so the site is not published yet. However, below's a screenshot of how the site should look.

![screencapture-stackbuilders-github-io-assertive-ts-2022-08-04-13_34_19](https://user-images.githubusercontent.com/3087228/182927122-286bd23a-f5e7-47d9-82be-3eaa074d4bf5.png)

