### PR TITLE
chore(gh-actions): Fix checkout actions ref branch

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+            ref: release
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: release
       - uses: cycjimmy/semantic-release-action@v3
         with:
           branch: release


### PR DESCRIPTION
This PR ensures that the `release.yml` and the `pages.yml` actions check out to the `release` branch. This doesn't happen automatically because the actions are triggered from a workflow instead of an `on: push` event, so it defaults to the main branch.

Documentation: https://github.com/actions/checkout