### PR TITLE
fix(core): Export TypeFactories and remove default export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,5 +3,9 @@ import { expect } from "./lib/expect";
 export { expect };
 export { expect as assert };
 export { expect as assertThat };
-
-export default expect;
+export {
+  type AssertionFactory,
+  type StaticTypeFactories,
+  type TypeFactory,
+  TypeFactories
+} from "./lib/helpers/TypeFactories";

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 
-import expect, { assert as libAssert, assertThat } from "../src";
+import { assert as libAssert, assertThat, expect, TypeFactories } from "../src";
 
 describe("[Unit] index.test.ts", () => {
   context("expect", () => {
@@ -18,6 +18,12 @@ describe("[Unit] index.test.ts", () => {
   context("assertThat", () => {
     it("is an alias of expect", () => {
       assert.deepStrictEqual(assertThat, expect);
+    });
+  });
+
+  context("TypeFactories", () => {
+    it("is exposed to the API", () => {
+      assert.ok(TypeFactories);
     });
   });
 });

--- a/test/lib/ArrayAssertion.test.ts
+++ b/test/lib/ArrayAssertion.test.ts
@@ -1,6 +1,6 @@
 import assert, { AssertionError } from "assert";
 
-import expect from "../../src";
+import { expect } from "../../src";
 import { ArrayAssertion } from "../../src/lib/ArrayAssertion";
 import { UnsupportedOperationError } from "../../src/lib/errors/UnsupportedOperationError";
 import { TypeFactories } from "../../src/lib/helpers/TypeFactories";

--- a/test/lib/expect.test.ts
+++ b/test/lib/expect.test.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 
-import expect from "../../src";
+import { expect } from "../../src";
 import { ArrayAssertion } from "../../src/lib/ArrayAssertion";
 import { Assertion } from "../../src/lib/Assertion";
 import { BooleanAssertion } from "../../src/lib/BooleanAssertion";


### PR DESCRIPTION
This PR fixes some export issues in the entry point of the library:
- Re-export `TypeFactories` and its types to make clearer the exposure on the API
- Remove the default export of `expect`. Now the library exports more than just the `expect` function in its entry point, so it doesn't make sense to make `expect` the default. Will add the default export again if it makes sense or if we get feedback in the future