### PR TITLE
Fix: DateAssertion.toBeDayOfWeek when using "sunday"

### DIFF
--- a/src/lib/DateAssertion.ts
+++ b/src/lib/DateAssertion.ts
@@ -24,9 +24,9 @@ export class DateAssertion extends Assertion<Date> {
   }
 
   /**
-   * Check if a day of the week, might be string
-   * (e.g 'monday') or number (e.g 0-6), equals the
-   * day of the actual date.
+   * Check if a day of the week equals the day of the actual date. You can pass
+   * either a string (e.g. "monday"), or a number from 0 to 6, where 0 is
+   * Sunday and 6 is Saturday, as in Date.getDay().
    *
    * @param dayOfWeek the day to compare with
    * @returns the assertion instance

--- a/src/lib/helpers/dates.ts
+++ b/src/lib/helpers/dates.ts
@@ -2,13 +2,13 @@ import { DateOptions, DayOfWeek, Month } from "../DateAssertion.types";
 
 export function dayOfWeekAsNumber (day: DayOfWeek): number {
     switch (day) {
+      case "sunday": return 0;
       case "monday": return 1;
       case "tuesday": return 2;
       case "wednesday": return 3;
       case "thursday": return 4;
       case "friday": return 5;
       case "saturday": return 6;
-      case "sunday": return 7;
     }
   }
 

--- a/test/lib/DateAssertion.test.ts
+++ b/test/lib/DateAssertion.test.ts
@@ -29,6 +29,19 @@ describe("[Unit] DateAssertion.test.ts", () => {
         assert.deepStrictEqual(test.not.toBeDayOfWeek(1), test);
       });
     });
+
+    context("when the day of the actual date is Sunday", () => {
+      context('when comparing to the "sunday" literal', () => {
+        it("does not raise an AssertionError", () => {
+          const actualDate = new Date(2022, 9, 2); // October 2nd, 2022
+          const test = new DateAssertion(actualDate);
+
+          assert.doesNotThrow(() => {
+            test.toBeDayOfWeek("sunday");
+          }, AssertionError);
+        });
+      });
+    });
   });
 
   describe(".toMatchDateParts", () => {


### PR DESCRIPTION
This PR fixes #75 . I chose this implementation so the `.toBeDayOfWeek` matcher's behavior is consistent with Javascript's `Date.getDay` and with `.toBeDayOfWeek`'s documentation. I also changed its docs so it's clear what a number literal means when using the matcher.

I also think there should be a `.toBeISODayOfWeek` matcher, to avoid further confusion.

### Changes

- Add a test that exposes the issue.
- Change convertion of "sunday" to 0 instead of 7.
- Improve `.toBeDayOfWeek` docs.