### PR TITLE
Fix: DateAssertion.toMatchDateParts when using month literals (#77)

### DIFF
--- a/src/lib/DateAssertion.ts
+++ b/src/lib/DateAssertion.ts
@@ -67,7 +67,7 @@ export class DateAssertion extends Assertion<Date> {
     const optionsAsDate = dateOptionsToDate(options);
     const assertWhen = Object.keys(options).every(key => {
       const dateMethod = DATE_METHOD_MAP[key];
-      return options[key] === this.actual[dateMethod]();
+      return optionsAsDate[dateMethod]() === this.actual[dateMethod]();
     });
     const error = new AssertionError({
       actual: this.actual,

--- a/test/lib/DateAssertion.test.ts
+++ b/test/lib/DateAssertion.test.ts
@@ -64,6 +64,20 @@ describe("[Unit] DateAssertion.test.ts", () => {
           name: AssertionError.name
         });
       });
+
+      context("when passing the month as a literal", () => {
+        it("does not throw an AssertionError", () => {
+          const actualDate = new Date(2021, 1, 1, 12, 10, 15, 25);
+          const options = { month: "february" as const };
+
+          const test = new DateAssertion(actualDate);
+
+          assert.doesNotThrow(
+            () => test.toMatchDateParts(options),
+            AssertionError
+          );
+        });
+      });
     });
 
     context("when the actual date is NOT equal to the passed date", () => {


### PR DESCRIPTION
Ths PR fixes #77 .  The issue was that the `DateAssertion.toMatchDateParts` was checking the actual date's fields with the exact fields from the options, instead of the fields of *the date* generated by the options.

A test that exposes the bug was also added.