### PR TITLE
fix(type-factories): Correct types on instanceOf type factory

### DIFF
--- a/packages/core/src/lib/helpers/TypeFactories.ts
+++ b/packages/core/src/lib/helpers/TypeFactories.ts
@@ -1,5 +1,5 @@
 import { ArrayAssertion } from "../ArrayAssertion";
-import { Assertion } from "../Assertion";
+import { Assertion, Constructor } from "../Assertion";
 import { BooleanAssertion } from "../BooleanAssertion";
 import { DateAssertion } from "../DateAssertion";
 import { AnyFunction, FunctionAssertion } from "../FunctionAssertion";
@@ -84,7 +84,7 @@ export interface StaticTypeFactories {
    * @typeParam T the type of the instance constructor
    * @param Type the instance constructor
    */
-  instanceOf<T extends new (...args: any[]) => any>(Type: T): TypeFactory<T, Assertion<T>>;
+  instanceOf<T>(Type: Constructor<T>): TypeFactory<T, Assertion<T>>;
   /**
    * Creates a TypeFactory for a Javascript Object.
    *
@@ -138,10 +138,10 @@ export const TypeFactories: Readonly<StaticTypeFactories> = {
       typeName: "array"
     };
   },
-  instanceOf(type) {
+  instanceOf<T>(type: Constructor<T>) {
     return {
       Factory: Assertion,
-      predicate: (value): value is typeof type => value instanceof type,
+      predicate: (value): value is T => value instanceof type,
       typeName: type.name
     };
   },


### PR DESCRIPTION
This PR corrects the types of the `TypeFactories.instanceOf(..)` helper. The issue was that the assertion factory was creating an assertion for the constructor instead of the instance. Using the alias `Constructor<T>` instead resolves the issue as the assertion factory will create an instance for `T` instead.

**Example:**
```ts
class Car {

  private model: string;

  constructor(model: string) {
    this.mode = model;
  }
}

expect(value)
  .asType(TypeFactories.instanceOf(Car))
  .toBeEqual(new Car("Porsche 911"));
```