### PR TITLE
feat(object-assertion): Matchers use variadic arguments

### DIFF
--- a/package/src/lib/ObjectAssertion.ts
+++ b/package/src/lib/ObjectAssertion.ts
@@ -36,6 +36,7 @@ export class ObjectAssertion<T extends Struct> extends Assertion<T> {
   public toBeEmpty(): this {
     const error = new AssertionError({
       actual: this.actual,
+      expected: { },
       message: "Expected the value to be an empty object",
     });
     const invertedError = new AssertionError({
@@ -83,20 +84,21 @@ export class ObjectAssertion<T extends Struct> extends Assertion<T> {
    *
    * @example
    * ```
-   * expect({ a: 1, b: 2, c: 3 }).toContainAllKeys(["a", "b"]);
+   * expect({ a: 1, b: 2, c: 3 }).toContainAllKeys("a", "b");
    * ```
    *
    * @param keys the keys that the object should contain
    * @returns the assertion instance
    */
-  public toContainAllKeys(keys: Array<keyof T>): this {
+  public toContainAllKeys(...keys: Array<keyof T>): this {
     const error = new AssertionError({
-      actual: this.actual,
+      actual: Object.keys(this.actual),
+      expected: keys,
       message: `Expected the object to contain all the provided keys <${prettify(keys)}>`,
     });
 
     const invertedError = new AssertionError({
-      actual: this.actual,
+      actual: Object.keys(this.actual),
       message: `Expected the object NOT to contain all the provided keys <${prettify(keys)}>`,
     });
     return this.execute({
@@ -111,20 +113,21 @@ export class ObjectAssertion<T extends Struct> extends Assertion<T> {
    *
    * @example
    * ```
-   * expect({ a: 1, b: 2, c: 3 }).toContainAnyKeys(["a", "b"]);
+   * expect({ a: 1, b: 2, c: 3 }).toContainAnyKeys("a", "b");
    * ```
    *
    * @param keys the keys that the object may contain
    * @returns the assertion instance
    */
-  public toContainAnyKeys(keys: Array<keyof T>): this {
+  public toContainAnyKeys(...keys: Array<keyof T>): this {
     const error = new AssertionError({
-      actual: this.actual,
+      actual: Object.keys(this.actual),
+      expected: keys,
       message: `Expected the object to contain at least one of the provided keys <${prettify(keys)}>`,
     });
 
     const invertedError = new AssertionError({
-      actual: this.actual,
+      actual: Object.keys(this.actual),
       message: `Expected the object NOT to contain any of the provided keys <${prettify(keys)}>`,
     });
     return this.execute({
@@ -168,20 +171,21 @@ export class ObjectAssertion<T extends Struct> extends Assertion<T> {
    *
    * @example
    * ```
-   * expect({ a: 1, b: 2, c: 3 }).toContainAllValues([1, 2]);
+   * expect({ a: 1, b: 2, c: 3 }).toContainAllValues(1, 2);
    * ```
    *
    * @param values the property values that the object should contain
    * @returns the assertion instance
    */
-  public toContainAllValues(values: Array<T[keyof T]>): this {
+  public toContainAllValues(...values: Array<T[keyof T]>): this {
     const error = new AssertionError({
-      actual: this.actual,
+      actual: Object.values(this.actual),
+      expected: values,
       message: `Expected the object to contain all the provided values <${prettify(values)}>`,
     });
 
     const invertedError = new AssertionError({
-      actual: this.actual,
+      actual: Object.values(this.actual),
       message: `Expected the object NOT to contain all the provided values <${prettify(values)}>`,
     });
     return this.execute({
@@ -199,20 +203,21 @@ export class ObjectAssertion<T extends Struct> extends Assertion<T> {
    *
    * @example
    * ```
-   * expect({ a: 1, b: 2, c: 3 }).toContainAnyValues([1, 5, 7]);
+   * expect({ a: 1, b: 2, c: 3 }).toContainAnyValues(1, 5, 7);
    * ```
    *
    * @param values the property values that the object should contain
    * @returns the assertion instance
    */
-  public toContainAnyValues(values: Array<T[keyof T]>): this {
+  public toContainAnyValues(...values: Array<T[keyof T]>): this {
     const error = new AssertionError({
-      actual: this.actual,
+      actual: Object.values(this.actual),
+      expected: values,
       message: `Expected the object to contain at least one of the provided values <${prettify(values)}>`,
     });
 
     const invertedError = new AssertionError({
-      actual: this.actual,
+      actual: Object.values(this.actual),
       message: `Expected the object NOT to contain any of the provided values <${prettify(values)}>`,
     });
     return this.execute({
@@ -268,12 +273,13 @@ export class ObjectAssertion<T extends Struct> extends Assertion<T> {
    */
   public toContainAllEntries(...entries: Array<Entry<T>>): this {
     const error = new AssertionError({
-      actual: this.actual,
+      actual: Object.entries(this.actual),
+      expected: entries,
       message: `Expected the object to contain all the provided entries <${prettify(entries)}>`,
     });
 
     const invertedError = new AssertionError({
-      actual: this.actual,
+      actual: Object.entries(this.actual),
       message: `Expected the object NOT to contain all the provided entries <${prettify(entries)}>`,
     });
     return this.execute({
@@ -301,12 +307,13 @@ export class ObjectAssertion<T extends Struct> extends Assertion<T> {
    */
   public toContainAnyEntries(...entries: Array<Entry<T>>): this {
     const error = new AssertionError({
-      actual: this.actual,
+      actual: Object.entries(this.actual),
+      expected: entries,
       message: `Expected the object to contain at least one of the provided entries <${prettify(entries)}>`,
     });
 
     const invertedError = new AssertionError({
-      actual: this.actual,
+      actual: Object.entries(this.actual),
       message: `Expected the object NOT to contain any of the provided entries <${prettify(entries)}>`,
     });
     return this.execute({
@@ -334,6 +341,7 @@ export class ObjectAssertion<T extends Struct> extends Assertion<T> {
   public toPartiallyMatch(other: Partial<T>): this {
     const error = new AssertionError({
       actual: this.actual,
+      expected: other,
       message: "Expected the object to be a partial match",
     });
 

--- a/package/test/lib/ObjectAssertion.test.ts
+++ b/package/test/lib/ObjectAssertion.test.ts
@@ -78,11 +78,11 @@ describe("[Unit] ObjectAssertion.test.ts", () => {
   describe(".toContainAllKeys", () => {
     context("when the object contains all the provided keys", () => {
       it("returns the assertion instance", () => {
-        const keys: Array<"myKey" | 2> = ["myKey", 2];
+        const keys: Array<keyof typeof TEST_OBJ> = ["myKey", 2];
         const test = new ObjectAssertion(TEST_OBJ);
 
-        assert.deepStrictEqual(test.toContainAllKeys(["myKey", 2]), test);
-        assert.throws(() => test.not.toContainAllKeys(keys), {
+        assert.deepStrictEqual(test.toContainAllKeys(...keys), test);
+        assert.throws(() => test.not.toContainAllKeys(...keys), {
           message: `Expected the object NOT to contain all the provided keys <${keys}>`,
           name: AssertionError.name,
         });
@@ -94,11 +94,11 @@ describe("[Unit] ObjectAssertion.test.ts", () => {
         const someKeys = ["truthy", "wrongKey"];
         const test = new ObjectAssertion(RECORD);
 
-        assert.throws(() => test.toContainAllKeys(someKeys), {
+        assert.throws(() => test.toContainAllKeys(...someKeys), {
           message: `Expected the object to contain all the provided keys <${someKeys}>`,
           name: AssertionError.name,
         });
-        assert.deepStrictEqual(test.not.toContainAllKeys(someKeys), test);
+        assert.deepStrictEqual(test.not.toContainAllKeys(...someKeys), test);
       });
     });
   });
@@ -109,8 +109,8 @@ describe("[Unit] ObjectAssertion.test.ts", () => {
         const someKeys = ["truthy", "wrongKey"];
         const test = new ObjectAssertion(RECORD);
 
-        assert.deepStrictEqual(test.toContainAnyKeys(someKeys), test);
-        assert.throws(() => test.not.toContainAnyKeys(someKeys), {
+        assert.deepStrictEqual(test.toContainAnyKeys(...someKeys), test);
+        assert.throws(() => test.not.toContainAnyKeys(...someKeys), {
           message: `Expected the object NOT to contain any of the provided keys <${someKeys}>`,
           name: AssertionError.name,
         });
@@ -122,11 +122,11 @@ describe("[Unit] ObjectAssertion.test.ts", () => {
         const wrongKeys = ["wrongKey", "randomKey"];
         const test = new ObjectAssertion(RECORD);
 
-        assert.throws(() => test.toContainAnyKeys(wrongKeys), {
+        assert.throws(() => test.toContainAnyKeys(...wrongKeys), {
           message: `Expected the object to contain at least one of the provided keys <${wrongKeys}>`,
           name: AssertionError.name,
         });
-        assert.deepStrictEqual(test.not.toContainAnyKeys(wrongKeys), test);
+        assert.deepStrictEqual(test.not.toContainAnyKeys(...wrongKeys), test);
       });
     });
   });
@@ -165,8 +165,8 @@ describe("[Unit] ObjectAssertion.test.ts", () => {
         const allValues = [0, { innerObjKey: 1, message: "inner value" }];
         const test = new ObjectAssertion(TEST_OBJ);
 
-        assert.deepStrictEqual(test.toContainAllValues(allValues), test);
-        assert.throws(() => test.not.toContainAllValues(allValues), {
+        assert.deepStrictEqual(test.toContainAllValues(...allValues), test);
+        assert.throws(() => test.not.toContainAllValues(...allValues), {
           message: `Expected the object NOT to contain all the provided values <${allValues}>`,
           name: AssertionError.name,
         });
@@ -178,11 +178,11 @@ describe("[Unit] ObjectAssertion.test.ts", () => {
         const someValues = [0, { innerObjKey: 1, message: "wrong inner value" }];
         const test = new ObjectAssertion(TEST_OBJ);
 
-        assert.throws(() => test.toContainAllValues(someValues), {
+        assert.throws(() => test.toContainAllValues(...someValues), {
           message: `Expected the object to contain all the provided values <${someValues}>`,
           name: AssertionError.name,
         });
-        assert.deepStrictEqual(test.not.toContainAllValues(someValues), test);
+        assert.deepStrictEqual(test.not.toContainAllValues(...someValues), test);
       });
     });
   });
@@ -193,8 +193,8 @@ describe("[Unit] ObjectAssertion.test.ts", () => {
         const someValues = [0, { innerObjKey: 1, message: "wrong inner value" }];
         const test = new ObjectAssertion(TEST_OBJ);
 
-        assert.deepStrictEqual(test.toContainAnyValues(someValues), test);
-        assert.throws(() => test.not.toContainAnyValues(someValues), {
+        assert.deepStrictEqual(test.toContainAnyValues(...someValues), test);
+        assert.throws(() => test.not.toContainAnyValues(...someValues), {
           message: `Expected the object NOT to contain any of the provided values <${someValues}>`,
           name: AssertionError.name,
         });
@@ -206,11 +206,11 @@ describe("[Unit] ObjectAssertion.test.ts", () => {
         const wrongValues = [10, { innerObjKey: 1, message: "wrong inner value" }];
         const test = new ObjectAssertion(TEST_OBJ);
 
-        assert.throws(() => test.toContainAnyValues(wrongValues), {
+        assert.throws(() => test.toContainAnyValues(...wrongValues), {
           message: `Expected the object to contain at least one of the provided values <${wrongValues}>`,
           name: AssertionError.name,
         });
-        assert.deepStrictEqual(test.not.toContainAnyValues(wrongValues), test);
+        assert.deepStrictEqual(test.not.toContainAnyValues(...wrongValues), test);
       });
     });
   });


### PR DESCRIPTION
This PR updates most of the `ObjectAssertion` matches to use variadic parameters. It also updates the `AssertionError` options so we can show diffs when the assertion fails, providing more complete information to the user.