### PR TITLE
feat(equallity): Use fast-deep-equal for faster deep equallity

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -30,7 +30,8 @@
     "test": "cross-env NODE_ENV=test TS_NODE_TRANSPILE_ONLY=true mocha"
   },
   "dependencies": {
-    "@cometlib/dedent": "^0.8.0-es.10"
+    "@cometlib/dedent": "^0.8.0-es.10",
+    "fast-deep-equal": "^3.1.3"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.1",

--- a/package/src/lib/ArrayAssertion.ts
+++ b/package/src/lib/ArrayAssertion.ts
@@ -1,3 +1,5 @@
+import isDeepEqual from "fast-deep-equal/es6";
+
 import { Assertion } from "./Assertion";
 import { UnsupportedOperationError } from "./errors/UnsupportedOperationError";
 import { type Expect } from "./expect";
@@ -5,7 +7,6 @@ import { type TypeFactory } from "./helpers/TypeFactories";
 import { prettify } from "./helpers/messages";
 
 import { AssertionError } from "assert";
-import { isDeepStrictEqual } from "util";
 
 /**
  * Encapsulates assertion methods applicable to arrays.
@@ -316,7 +317,7 @@ export class ArrayAssertion<T> extends Assertion<T[]> {
     });
 
     return this.execute({
-      assertWhen: isDeepStrictEqual(this.actual[index], value),
+      assertWhen: isDeepEqual(this.actual[index], value),
       error,
       invertedError,
     });

--- a/package/src/lib/Assertion.ts
+++ b/package/src/lib/Assertion.ts
@@ -1,10 +1,11 @@
+import isDeepEqual from "fast-deep-equal/es6";
+
 import { UnsupportedOperationError } from "./errors/UnsupportedOperationError";
 import { type TypeFactory } from "./helpers/TypeFactories";
 import { isStruct, isKeyOf } from "./helpers/guards";
 import { prettify } from "./helpers/messages";
 
 import { AssertionError } from "assert";
-import { isDeepStrictEqual } from "util";
 
 export interface Constructor<T> extends Function {
   prototype: T;
@@ -330,7 +331,7 @@ export class Assertion<T> {
     });
 
     return this.execute({
-      assertWhen: isDeepStrictEqual(this.actual, expected),
+      assertWhen: isDeepEqual(this.actual, expected),
       error,
       invertedError,
     });

--- a/package/src/lib/FunctionAssertion.ts
+++ b/package/src/lib/FunctionAssertion.ts
@@ -1,10 +1,11 @@
+import isDeepEqual from "fast-deep-equal/es6";
+
 import { Assertion, Constructor } from "./Assertion";
 import { ErrorAssertion } from "./ErrorAssertion";
 import { type TypeFactory } from "./helpers/TypeFactories";
 import { prettify } from "./helpers/messages";
 
 import { AssertionError } from "assert";
-import { isDeepStrictEqual } from "util";
 
 export type AnyFunction = (...args: unknown[]) => unknown;
 
@@ -55,7 +56,7 @@ export class FunctionAssertion<T extends AnyFunction> extends Assertion<T> {
 
     if (error !== undefined) {
       return this.execute({
-        assertWhen: isDeepStrictEqual(captured, error),
+        assertWhen: isDeepEqual(captured, error),
         error: new AssertionError({
           actual: captured,
           expected: error,

--- a/package/src/lib/ObjectAssertion.ts
+++ b/package/src/lib/ObjectAssertion.ts
@@ -1,9 +1,10 @@
+import isDeepEqual from "fast-deep-equal/es6";
+
 import { Assertion } from "./Assertion";
 import { prettify } from "./helpers/messages";
 import { Entry, Struct } from "./helpers/types";
 
 import { AssertionError } from "assert";
-import { isDeepStrictEqual } from "util";
 
 /**
  * Encapsulates assertion methods applicable to objects.
@@ -160,7 +161,7 @@ export class ObjectAssertion<T extends Struct> extends Assertion<T> {
       message: `Expected the object NOT to contain the provided value <${prettify(value)}>`,
     });
     return this.execute({
-      assertWhen: Object.values(this.actual).some(actualValue => isDeepStrictEqual(actualValue, value)),
+      assertWhen: Object.values(this.actual).some(actualValue => isDeepEqual(actualValue, value)),
       error,
       invertedError,
     });
@@ -191,7 +192,7 @@ export class ObjectAssertion<T extends Struct> extends Assertion<T> {
     return this.execute({
       assertWhen: values
         .every(value =>
-          Object.values(this.actual).some(actualValue => isDeepStrictEqual(actualValue, value)),
+          Object.values(this.actual).some(actualValue => isDeepEqual(actualValue, value)),
         ),
       error,
       invertedError,
@@ -223,7 +224,7 @@ export class ObjectAssertion<T extends Struct> extends Assertion<T> {
     return this.execute({
       assertWhen: values
         .some(value =>
-          Object.values(this.actual).some(actualValue => isDeepStrictEqual(actualValue, value)),
+          Object.values(this.actual).some(actualValue => isDeepEqual(actualValue, value)),
         ),
       error,
       invertedError,
@@ -254,7 +255,7 @@ export class ObjectAssertion<T extends Struct> extends Assertion<T> {
     return this.execute({
       assertWhen:
         this.hasOwnProp(entry[0]) &&
-        isDeepStrictEqual(Object.getOwnPropertyDescriptor(this.actual, entry[0])?.value, entry[1]),
+        isDeepEqual(Object.getOwnPropertyDescriptor(this.actual, entry[0])?.value, entry[1]),
       error,
       invertedError,
     });
@@ -286,7 +287,7 @@ export class ObjectAssertion<T extends Struct> extends Assertion<T> {
       assertWhen: entries
         .every(entry =>
           this.hasOwnProp(entry[0]) &&
-          isDeepStrictEqual(Object.getOwnPropertyDescriptor(this.actual, entry[0])?.value, entry[1]),
+          isDeepEqual(Object.getOwnPropertyDescriptor(this.actual, entry[0])?.value, entry[1]),
         ),
       error,
       invertedError,
@@ -320,7 +321,7 @@ export class ObjectAssertion<T extends Struct> extends Assertion<T> {
       assertWhen: entries
         .some(entry =>
           this.hasOwnProp(entry[0]) &&
-          isDeepStrictEqual(Object.getOwnPropertyDescriptor(this.actual, entry[0])?.value, entry[1]),
+          isDeepEqual(Object.getOwnPropertyDescriptor(this.actual, entry[0])?.value, entry[1]),
         ),
       error,
       invertedError,
@@ -353,7 +354,7 @@ export class ObjectAssertion<T extends Struct> extends Assertion<T> {
       assertWhen: Object.keys(other)
         .every(key =>
           this.hasOwnProp(key)
-            ? isDeepStrictEqual(Object.getOwnPropertyDescriptor(this.actual, key)?.value, other[key])
+            ? isDeepEqual(Object.getOwnPropertyDescriptor(this.actual, key)?.value, other[key])
             : false,
         ),
       error,

--- a/package/src/lib/PromiseAssertion.ts
+++ b/package/src/lib/PromiseAssertion.ts
@@ -1,10 +1,10 @@
 import dedent from "@cometlib/dedent";
+import isDeepEqual from "fast-deep-equal/es6";
 
 import { Assertion } from "./Assertion";
 import { prettify } from "./helpers/messages";
 
 import { AssertionError } from "assert/strict";
-import { isDeepStrictEqual } from "util";
 
 /**
  * Encapsulates assertion methods applicable to Promises
@@ -87,7 +87,7 @@ export class PromiseAssertion<T, I extends boolean = false> extends Assertion<Pr
   public toBeResolvedWith(expected: T): Promise<I extends false ? T : unknown> {
     return this.actual.then(value => {
       this.execute({
-        assertWhen: isDeepStrictEqual(value, expected),
+        assertWhen: isDeepEqual(value, expected),
         error: new AssertionError({
           actual: value,
           expected,
@@ -203,7 +203,7 @@ export class PromiseAssertion<T, I extends boolean = false> extends Assertion<Pr
       }
 
       this.execute({
-        assertWhen: isDeepStrictEqual(error, expected),
+        assertWhen: isDeepEqual(error, expected),
         error: new AssertionError({
           actual: error,
           expected,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1502,6 +1502,7 @@ __metadata:
     "@types/sinon": ^10.0.15
     all-contributors-cli: ^6.26.0
     cross-env: ^7.0.3
+    fast-deep-equal: ^3.1.3
     mocha: ^10.2.0
     semantic-release: ^21.0.6
     sinon: ^15.2.0


### PR DESCRIPTION
This PR changes the depp equality comparator from the default node to the faster [fast-deep-equal](https://github.com/epoberezkin/fast-deep-equal) so we can have increased performance on big deep objects.