### PR TITLE
chore(release): Use semantic-release-yarn to support monorepos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
 
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -24,10 +30,10 @@ jobs:
           cache: yarn
       - run: yarn install --immutable
       - run: yarn build
-      - run: cd package/ && yarn release
+      - run: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   pages:
     uses: ./.github/workflows/pages.yml

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "compile": "turbo run compile",
     "docs": "yarn workspace @stackbuilders/assertive-ts docs",
     "lint": "eslint .",
+    "release": "turbo release --concurrency=1",
     "test": "turbo run test"
   },
   "devDependencies": {

--- a/package/.npmrc
+++ b/package/.npmrc
@@ -1,1 +1,0 @@
-workspaces-update = false

--- a/package/.releaserc.json
+++ b/package/.releaserc.json
@@ -2,5 +2,11 @@
   "$schema": "https://json.schemastore.org/semantic-release",
   "branches": [
     "main"
+  ],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "semantic-release-yarn",
+    "@semantic-release/github"
   ]
 }

--- a/package/package.json
+++ b/package/package.json
@@ -28,7 +28,7 @@
     "compile": "tsc -p tsconfig.json",
     "docs": "typedoc",
     "release": "semantic-release",
-    "test": "cross-env NODE_ENV=test mocha"
+    "test": "NODE_ENV=test mocha"
   },
   "dependencies": {
     "@cometlib/dedent": "^0.8.0-es.10",
@@ -39,9 +39,9 @@
     "@types/node": "^20.3.2",
     "@types/sinon": "^10.0.15",
     "all-contributors-cli": "^6.26.0",
-    "cross-env": "^7.0.3",
     "mocha": "^10.2.0",
     "semantic-release": "^21.0.6",
+    "semantic-release-yarn": "^2.0.0",
     "sinon": "^15.2.0",
     "ts-node": "^10.9.1",
     "typedoc": "^0.24.8",

--- a/turbo.json
+++ b/turbo.json
@@ -14,6 +14,10 @@
       "dependsOn": ["^build"],
       "outputs": ["build/**"]
     },
+    "release": {
+      "cache": false,
+      "dependsOn": ["^build"]
+    },
     "test": {
       "dependsOn": ["^build"],
       "inputs": ["src/**/*.ts", "test/**/*.ts"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1346,6 +1346,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@semantic-release/error@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@semantic-release/error@npm:3.0.0"
+  checksum: 29c4391ecbefd9ea991f8fdf5ab3ceb9c4830281da56d9dbacd945c476cb86f10c3b55cd4a6597098c0ea3a59f1ec4752132abeea633e15972f49f4704e61d35
+  languageName: node
+  linkType: hard
+
 "@semantic-release/error@npm:^4.0.0":
   version: 4.0.0
   resolution: "@semantic-release/error@npm:4.0.0"
@@ -1501,10 +1508,10 @@ __metadata:
     "@types/node": ^20.3.2
     "@types/sinon": ^10.0.15
     all-contributors-cli: ^6.26.0
-    cross-env: ^7.0.3
     fast-deep-equal: ^3.1.3
     mocha: ^10.2.0
     semantic-release: ^21.0.6
+    semantic-release-yarn: ^2.0.0
     sinon: ^15.2.0
     ts-node: ^10.9.1
     typedoc: ^0.24.8
@@ -3025,7 +3032,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cosmiconfig@npm:^8.0.0":
+"cosmiconfig@npm:^8.0.0, cosmiconfig@npm:^8.1.0":
   version: 8.2.0
   resolution: "cosmiconfig@npm:8.2.0"
   dependencies:
@@ -3044,19 +3051,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-env@npm:^7.0.3":
-  version: 7.0.3
-  resolution: "cross-env@npm:7.0.3"
-  dependencies:
-    cross-spawn: ^7.0.1
-  bin:
-    cross-env: src/bin/cross-env.js
-    cross-env-shell: src/bin/cross-env-shell.js
-  checksum: 26f2f3ea2ab32617f57effb70d329c2070d2f5630adc800985d8b30b56e8bf7f5f439dd3a0358b79cee6f930afc23cf8e23515f17ccfb30092c6b62c6b630a79
-  languageName: node
-  linkType: hard
-
-"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.1, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
@@ -4072,7 +4067,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^11.0.0":
+"fs-extra@npm:^11.0.0, fs-extra@npm:^11.1.0":
   version: 11.1.1
   resolution: "fs-extra@npm:11.1.1"
   dependencies:
@@ -8011,6 +8006,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semantic-release-yarn@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "semantic-release-yarn@npm:2.0.0"
+  dependencies:
+    "@semantic-release/error": ^3.0.0
+    aggregate-error: ^4.0.1
+    cosmiconfig: ^8.1.0
+    execa: ^7.0.0
+    fs-extra: ^11.1.0
+    js-yaml: ^4.1.0
+    lodash: ^4.17.21
+    nerf-dart: ^1.0.0
+    read-pkg: ^8.0.0
+    semver: ^7.3.8
+  peerDependencies:
+    semantic-release: ">=19.0.0"
+  checksum: 4b0a7554c1b9409a3907fac6a0fd6e8ef9d9494339862f57d017bc17204040cd3a8a62ef8ea5d5682dce3fc0b80a1251ef2e89a4817b227d48e3fead2a79f893
+  languageName: node
+  linkType: hard
+
 "semantic-release@npm:^21.0.6":
   version: 21.0.6
   resolution: "semantic-release@npm:21.0.6"
@@ -8091,6 +8106,17 @@ __metadata:
   bin:
     semver: ./bin/semver.js
   checksum: 1b26ecf6db9e8292dd90df4e781d91875c0dcc1b1909e70f5d12959a23c7eebb8f01ea581c00783bbee72ceeaad9505797c381756326073850dc36ed284b21b9
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.3.8":
+  version: 7.5.4
+  resolution: "semver@npm:7.5.4"
+  dependencies:
+    lru-cache: ^6.0.0
+  bin:
+    semver: bin/semver.js
+  checksum: 12d8ad952fa353b0995bf180cdac205a4068b759a140e5d3c608317098b3575ac2f1e09182206bf2eb26120e1c0ed8fb92c48c592f6099680de56bb071423ca3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR changes the release workflow to use the [semantic-release-yarn](https://github.com/hongaar/semantic-release-yarn) plugin instead of the usual `@semantic-release/npm` to publish the package. The new plugin is intended to publish using Yarn 2.0+ while supporting workspaces for monorepo project structures.