### PR TITLE
feat(core): Add normalized() helper to Assertion base class

### DIFF
--- a/packages/core/src/lib/Assertion.ts
+++ b/packages/core/src/lib/Assertion.ts
@@ -61,7 +61,7 @@ export class Assertion<T> {
   }
 
   /**
-   * A convenience method to normalized the assertion instance. If it was
+   * A convenience method to normalize the assertion instance. If it was
    * inverted with `.not`, it'll return it back to the previous non-inverted
    * state. Otherwise, it returns the same instance.
    *


### PR DESCRIPTION
This helper will allow classes extending from `Assertion` to create matcher methods which don't need the `this.execure(..)` method:
```ts
public someMatcher(): this {
  if (this.inverted) {
    // ...assert inverted somehow
  } else {
    // ...assert somehow
  }

  return this.normalized();
}
```