### PR TITLE
feat: Include aliases toBeSameAs and toBe for toBeSame

### DIFF
--- a/packages/core/src/lib/Assertion.ts
+++ b/packages/core/src/lib/Assertion.ts
@@ -46,7 +46,6 @@ export interface ExecuteOptions {
  * @param T the type of the `actual` value
  */
 export class Assertion<T> {
-
   protected readonly actual: T;
 
   protected readonly inverted: boolean;
@@ -136,7 +135,9 @@ export class Assertion<T> {
     });
     const invertedError = new AssertionError({
       actual: this.actual,
-      message: `Expected value to NOT exist, but it was <${prettify(this.actual)}>`,
+      message: `Expected value to NOT exist, but it was <${prettify(
+        this.actual
+      )}>`,
     });
 
     return this.execute({
@@ -379,13 +380,15 @@ export class Assertion<T> {
       }
 
       if (
-        (isStruct(this.actual) && isStruct(expected))
-        || (Array.isArray(this.actual) && Array.isArray(expected))
+        (isStruct(this.actual) && isStruct(expected)) ||
+        (Array.isArray(this.actual) && Array.isArray(expected))
       ) {
         const actualKeys = Object.keys(this.actual);
         const expectedKeys = Object.keys(expected);
         const sizeMatch = actualKeys.length === expectedKeys.length;
-        const valuesMatch = actualKeys.every(key => this.actual[key] === expected[key]);
+        const valuesMatch = actualKeys.every(
+          (key) => this.actual[key] === expected[key]
+        );
 
         return sizeMatch && valuesMatch;
       }
@@ -393,10 +396,11 @@ export class Assertion<T> {
       return Object.is(this.actual, expected);
     };
 
-    const areBothNaN = typeof this.actual === "number"
-      && typeof expected === "number"
-      && isNaN(this.actual)
-      && isNaN(expected);
+    const areBothNaN =
+      typeof this.actual === "number" &&
+      typeof expected === "number" &&
+      isNaN(this.actual) &&
+      isNaN(expected);
 
     return this.execute({
       assertWhen: areShallowEqual() || areBothNaN || this.actual === expected,
@@ -441,6 +445,48 @@ export class Assertion<T> {
   }
 
   /**
+   * Alias of `.toBeSame(..)` assertion.
+   *
+   * @example
+   * ```
+   * const x = { a: 1 };
+   * const y = x;
+   *
+   * expect(x).toBeSameAs(x);
+   * expect(x).toBeSameAs(y);
+   *
+   * expect(x).not.toBeSameAs({ ...x });
+   * ```
+   *
+   * @param expected the value to compare for referential equality
+   * @returns the assertion instance
+   */
+  public toBeSameAs(expected: T): this {
+    return this.toBeSame(expected);
+  }
+
+  /**
+   * Another alias of `.toBeSame(..)` assertion.
+   *
+   * @example
+   * ```
+   * const x = { a: 1 };
+   * const y = x;
+   *
+   * expect(x).toBe(x);
+   * expect(x).toBe(y);
+   *
+   * expect(x).not.toBe({ ...x });
+   * ```
+   *
+   * @param expected the value to compare for referential equality
+   * @returns the assertion instance
+   */
+  public toBe(expected: T): this {
+    return this.toBeSame(expected);
+  }
+
+  /**
    * Checks if the value is of a specific data type. The supported data types
    * are the same as the `typeof` operator, plus an additional `array` which
    * allows desabiguation between `object` (which can also be an array).
@@ -461,17 +507,22 @@ export class Assertion<T> {
     const error = new AssertionError({
       actual: typeof this.actual,
       expected,
-      message: `Expected <${prettify(this.actual)}> to be of type <${expected}>`,
+      message: `Expected <${prettify(
+        this.actual
+      )}> to be of type <${expected}>`,
     });
     const invertedError = new AssertionError({
       actual: typeof this.actual,
-      message: `Expected <${prettify(this.actual)}> NOT to be of type <${expected}>`,
+      message: `Expected <${prettify(
+        this.actual
+      )}> NOT to be of type <${expected}>`,
     });
 
     return this.execute({
-      assertWhen: expected === "array"
-        ? Array.isArray(this.actual)
-        : typeof this.actual === expected,
+      assertWhen:
+        expected === "array"
+          ? Array.isArray(this.actual)
+          : typeof this.actual === expected,
       error,
       invertedError,
     });
@@ -511,7 +562,9 @@ export class Assertion<T> {
     const { Factory, predicate, typeName } = typeFactory;
 
     if (this.inverted) {
-      throw new UnsupportedOperationError("The `.not` modifier is not allowed on `.asType(..)` method");
+      throw new UnsupportedOperationError(
+        "The `.not` modifier is not allowed on `.asType(..)` method"
+      );
     }
 
     if (predicate(this.actual)) {
@@ -520,7 +573,9 @@ export class Assertion<T> {
 
     throw new AssertionError({
       actual: this.actual,
-      message: `Expected <${prettify(this.actual)}> to be of type "${typeName}"`,
+      message: `Expected <${prettify(
+        this.actual
+      )}> to be of type "${typeName}"`,
     });
   }
 

--- a/packages/core/src/lib/Assertion.ts
+++ b/packages/core/src/lib/Assertion.ts
@@ -136,7 +136,7 @@ export class Assertion<T> {
     const invertedError = new AssertionError({
       actual: this.actual,
       message: `Expected value to NOT exist, but it was <${prettify(
-        this.actual
+        this.actual,
       )}>`,
     });
 
@@ -387,7 +387,7 @@ export class Assertion<T> {
         const expectedKeys = Object.keys(expected);
         const sizeMatch = actualKeys.length === expectedKeys.length;
         const valuesMatch = actualKeys.every(
-          (key) => this.actual[key] === expected[key]
+          key => this.actual[key] === expected[key],
         );
 
         return sizeMatch && valuesMatch;
@@ -508,13 +508,13 @@ export class Assertion<T> {
       actual: typeof this.actual,
       expected,
       message: `Expected <${prettify(
-        this.actual
+        this.actual,
       )}> to be of type <${expected}>`,
     });
     const invertedError = new AssertionError({
       actual: typeof this.actual,
       message: `Expected <${prettify(
-        this.actual
+        this.actual,
       )}> NOT to be of type <${expected}>`,
     });
 
@@ -563,7 +563,7 @@ export class Assertion<T> {
 
     if (this.inverted) {
       throw new UnsupportedOperationError(
-        "The `.not` modifier is not allowed on `.asType(..)` method"
+        "The `.not` modifier is not allowed on `.asType(..)` method",
       );
     }
 
@@ -574,7 +574,7 @@ export class Assertion<T> {
     throw new AssertionError({
       actual: this.actual,
       message: `Expected <${prettify(
-        this.actual
+        this.actual,
       )}> to be of type "${typeName}"`,
     });
   }

--- a/packages/core/src/lib/Assertion.ts
+++ b/packages/core/src/lib/Assertion.ts
@@ -46,6 +46,7 @@ export interface ExecuteOptions {
  * @param T the type of the `actual` value
  */
 export class Assertion<T> {
+
   protected readonly actual: T;
 
   protected readonly inverted: boolean;
@@ -135,9 +136,7 @@ export class Assertion<T> {
     });
     const invertedError = new AssertionError({
       actual: this.actual,
-      message: `Expected value to NOT exist, but it was <${prettify(
-        this.actual,
-      )}>`,
+      message: `Expected value to NOT exist, but it was <${prettify(this.actual)}>`,
     });
 
     return this.execute({
@@ -380,15 +379,13 @@ export class Assertion<T> {
       }
 
       if (
-        (isStruct(this.actual) && isStruct(expected)) ||
-        (Array.isArray(this.actual) && Array.isArray(expected))
+        (isStruct(this.actual) && isStruct(expected))
+        || (Array.isArray(this.actual) && Array.isArray(expected))
       ) {
         const actualKeys = Object.keys(this.actual);
         const expectedKeys = Object.keys(expected);
         const sizeMatch = actualKeys.length === expectedKeys.length;
-        const valuesMatch = actualKeys.every(
-          key => this.actual[key] === expected[key],
-        );
+        const valuesMatch = actualKeys.every(key => this.actual[key] === expected[key]);
 
         return sizeMatch && valuesMatch;
       }
@@ -396,11 +393,10 @@ export class Assertion<T> {
       return Object.is(this.actual, expected);
     };
 
-    const areBothNaN =
-      typeof this.actual === "number" &&
-      typeof expected === "number" &&
-      isNaN(this.actual) &&
-      isNaN(expected);
+    const areBothNaN = typeof this.actual === "number"
+      && typeof expected === "number"
+      && isNaN(this.actual)
+      && isNaN(expected);
 
     return this.execute({
       assertWhen: areShallowEqual() || areBothNaN || this.actual === expected,
@@ -507,22 +503,17 @@ export class Assertion<T> {
     const error = new AssertionError({
       actual: typeof this.actual,
       expected,
-      message: `Expected <${prettify(
-        this.actual,
-      )}> to be of type <${expected}>`,
+      message: `Expected <${prettify(this.actual)}> to be of type <${expected}>`,
     });
     const invertedError = new AssertionError({
       actual: typeof this.actual,
-      message: `Expected <${prettify(
-        this.actual,
-      )}> NOT to be of type <${expected}>`,
+      message: `Expected <${prettify(this.actual)}> NOT to be of type <${expected}>`,
     });
 
     return this.execute({
-      assertWhen:
-        expected === "array"
-          ? Array.isArray(this.actual)
-          : typeof this.actual === expected,
+      assertWhen: expected === "array"
+        ? Array.isArray(this.actual)
+        : typeof this.actual === expected,
       error,
       invertedError,
     });
@@ -562,9 +553,7 @@ export class Assertion<T> {
     const { Factory, predicate, typeName } = typeFactory;
 
     if (this.inverted) {
-      throw new UnsupportedOperationError(
-        "The `.not` modifier is not allowed on `.asType(..)` method",
-      );
+      throw new UnsupportedOperationError("The `.not` modifier is not allowed on `.asType(..)` method");
     }
 
     if (predicate(this.actual)) {
@@ -573,9 +562,7 @@ export class Assertion<T> {
 
     throw new AssertionError({
       actual: this.actual,
-      message: `Expected <${prettify(
-        this.actual,
-      )}> to be of type "${typeName}"`,
+      message: `Expected <${prettify(this.actual)}> to be of type "${typeName}"`,
     });
   }
 

--- a/packages/core/test/lib/Assertion.test.ts
+++ b/packages/core/test/lib/Assertion.test.ts
@@ -1,3 +1,5 @@
+import Sinon from "sinon";
+
 import { Assertion, DataType } from "../../src/lib/Assertion";
 import { StringAssertion } from "../../src/lib/StringAssertion";
 import { UnsupportedOperationError } from "../../src/lib/errors/UnsupportedOperationError";
@@ -13,23 +15,9 @@ const HERO = {
 
 const THINGS = [1, "foo", false];
 
-const TRUTHY_VALUES = [
-  true,
-  1,
-  "foo",
-  { },
-  [],
-  new Date(),
-];
+const TRUTHY_VALUES = [true, 1, "foo", {}, [], new Date()];
 
-const FALSY_VALUES = [
-  null,
-  undefined,
-  0,
-  "",
-  false,
-  NaN,
-];
+const FALSY_VALUES = [null, undefined, 0, "", false, NaN];
 
 const TODAY = new Date("2021-12-10T00:00:00.000Z");
 
@@ -54,7 +42,6 @@ const BASE_DIFFS = [
 ];
 
 class Car {
-
   private readonly model: string;
 
   public constructor(model: string) {
@@ -66,7 +53,7 @@ class Car {
   }
 }
 
-function truthyAsText(value: typeof TRUTHY_VALUES[number]): string {
+function truthyAsText(value: (typeof TRUTHY_VALUES)[number]): string {
   if (Array.isArray(value) && value.length === 0) {
     return "Empty array";
   }
@@ -82,10 +69,8 @@ function truthyAsText(value: typeof TRUTHY_VALUES[number]): string {
   return String(value);
 }
 
-function falsyAsText(value: typeof FALSY_VALUES[number]): string {
-  return value === ""
-    ? '""'
-    : `${value}`;
+function falsyAsText(value: (typeof FALSY_VALUES)[number]): string {
+  return value === "" ? '""' : `${value}`;
 }
 
 describe("[Unit] Assertion.test.ts", () => {
@@ -150,7 +135,7 @@ describe("[Unit] Assertion.test.ts", () => {
       });
     });
 
-    [undefined, null].forEach(value => {
+    [undefined, null].forEach((value) => {
       context(`when the value is ${value}`, () => {
         it("throws an assertion error", () => {
           const test = new Assertion(value);
@@ -245,7 +230,7 @@ describe("[Unit] Assertion.test.ts", () => {
 
   describe(".toBeTruthy", () => {
     context("when the value is truthy", () => {
-      TRUTHY_VALUES.forEach(value => {
+      TRUTHY_VALUES.forEach((value) => {
         it(`[${truthyAsText(value)}] returns the assertion instance`, () => {
           const test = new Assertion(value);
 
@@ -259,7 +244,7 @@ describe("[Unit] Assertion.test.ts", () => {
     });
 
     context("when the value is NOT truthy", () => {
-      FALSY_VALUES.forEach(value => {
+      FALSY_VALUES.forEach((value) => {
         it(`[${falsyAsText(value)}] throws an assertion error`, () => {
           const test = new Assertion(value);
 
@@ -275,7 +260,7 @@ describe("[Unit] Assertion.test.ts", () => {
 
   describe(".toBeFalsy", () => {
     context("when the value is falsy", () => {
-      FALSY_VALUES.forEach(value => {
+      FALSY_VALUES.forEach((value) => {
         it(`[${falsyAsText(value)}] returns the assertion instance`, () => {
           const test = new Assertion(value);
 
@@ -289,7 +274,7 @@ describe("[Unit] Assertion.test.ts", () => {
     });
 
     context("when the value NOT falsy", () => {
-      TRUTHY_VALUES.forEach(value => {
+      TRUTHY_VALUES.forEach((value) => {
         it(`[${truthyAsText(value)}] throws an assertion error`, () => {
           const test = new Assertion(value);
 
@@ -347,8 +332,7 @@ describe("[Unit] Assertion.test.ts", () => {
         ["deep-object", { ...HERO, opts: THINGS }, { ...HERO, opts: THINGS }],
         ["deep-array", [...THINGS, { x: HERO }], [...THINGS, { x: HERO }]],
         ["date", TODAY, new Date(TODAY.toISOString())],
-      ]
-      .forEach(([type, actual, expected]) => {
+      ].forEach(([type, actual, expected]) => {
         it(`[${type}] returns the assertion instance`, () => {
           const test = new Assertion(actual);
 
@@ -361,29 +345,35 @@ describe("[Unit] Assertion.test.ts", () => {
       });
     });
 
-    context("when the value is NOT referentially, NOR shallow, NOR deep equal", () => {
-      [
-        ...BASE_DIFFS,
-        ["NaN", NaN, 5],
-        ["object-ref", HERO, { ...HERO, x: 1 }],
-        ["array-ref", THINGS, [...THINGS, "banana"]],
-        ["shallow-object", { ...HERO }, { ...HERO, foo: { x: 1 } }],
-        ["shallow-array", [1, 2, 3], [1, 2, 3, { x: 4 }]],
-        ["deep-object", { ...HERO, opts: { x: 1 } }, { ...HERO, opts: { x: 2 } }],
-        ["deep-array", [...THINGS, { x: 1 }], [...THINGS, { x: 2 }]],
-      ]
-      .forEach(([type, actual, expected]) => {
-        it(`[${type}] throws an assertion error`, () => {
-          const test = new Assertion(actual);
+    context(
+      "when the value is NOT referentially, NOR shallow, NOR deep equal",
+      () => {
+        [
+          ...BASE_DIFFS,
+          ["NaN", NaN, 5],
+          ["object-ref", HERO, { ...HERO, x: 1 }],
+          ["array-ref", THINGS, [...THINGS, "banana"]],
+          ["shallow-object", { ...HERO }, { ...HERO, foo: { x: 1 } }],
+          ["shallow-array", [1, 2, 3], [1, 2, 3, { x: 4 }]],
+          [
+            "deep-object",
+            { ...HERO, opts: { x: 1 } },
+            { ...HERO, opts: { x: 2 } },
+          ],
+          ["deep-array", [...THINGS, { x: 1 }], [...THINGS, { x: 2 }]],
+        ].forEach(([type, actual, expected]) => {
+          it(`[${type}] throws an assertion error`, () => {
+            const test = new Assertion(actual);
 
-          assert.throws(() => test.toBeEqual(expected), {
-            message: "Expected both values to be deep equal",
-            name: AssertionError.name,
+            assert.throws(() => test.toBeEqual(expected), {
+              message: "Expected both values to be deep equal",
+              name: AssertionError.name,
+            });
+            assert.deepStrictEqual(test.not.toBeEqual(expected), test);
           });
-          assert.deepStrictEqual(test.not.toBeEqual(expected), test);
         });
-      });
-    });
+      }
+    );
   });
 
   describe(".toBeSimilar", () => {
@@ -393,8 +383,7 @@ describe("[Unit] Assertion.test.ts", () => {
         ["NaN", NaN, NaN], // Shallow equality has a workaround for `NaN === NaN`
         ["shallow-object", HERO, { name: "Batman", realName: "Bruce Wayne" }],
         ["shallow-array", THINGS, [1, "foo", false]],
-      ]
-      .forEach(([valueType, expected, actual]) => {
+      ].forEach(([valueType, expected, actual]) => {
         it(`[${valueType}] returns the assertion instance`, () => {
           const test = new Assertion(actual);
 
@@ -413,12 +402,19 @@ describe("[Unit] Assertion.test.ts", () => {
         ["NaN", NaN, 5],
         ["object-ref", HERO, { ...HERO, x: 1 }],
         ["array-ref", THINGS, [...THINGS, "banana"]],
-        ["shallow-object", { ...HERO, opt: [...THINGS] }, { ...HERO, opt: [...THINGS] }],
+        [
+          "shallow-object",
+          { ...HERO, opt: [...THINGS] },
+          { ...HERO, opt: [...THINGS] },
+        ],
         ["shallow-array", [1, 2, { hero: HERO }], [1, 2, { hero: HERO }]],
-        ["deep-object", { ...HERO, opts: { x: THINGS } }, { ...HERO, opts: { x: THINGS } }],
+        [
+          "deep-object",
+          { ...HERO, opts: { x: THINGS } },
+          { ...HERO, opts: { x: THINGS } },
+        ],
         ["deep-array", [...THINGS, { x: 1 }], [...THINGS, { x: 1 }]],
-      ]
-      .forEach(([type, actual, expected]) => {
+      ].forEach(([type, actual, expected]) => {
         it(`[${type}] throws an assertion error`, () => {
           const test = new Assertion(actual);
 
@@ -455,10 +451,13 @@ describe("[Unit] Assertion.test.ts", () => {
         ["array-ref", [...THINGS], [...THINGS]],
         ["shallow-object", HERO, { name: "Batman", realName: "Bruce Wayne" }],
         ["shallow-array", THINGS, [1, "foo", false]],
-        ["deep-object", { ...HERO, opts: { x: THINGS } }, { ...HERO, opts: { x: THINGS } }],
+        [
+          "deep-object",
+          { ...HERO, opts: { x: THINGS } },
+          { ...HERO, opts: { x: THINGS } },
+        ],
         ["deep-array", [...THINGS, { x: 1 }], [...THINGS, { x: 1 }]],
-      ]
-      .forEach(([type, actual, expected]) => {
+      ].forEach(([type, actual, expected]) => {
         it(`[${type}] throws an assertion error`, () => {
           const test = new Assertion(actual);
 
@@ -469,6 +468,28 @@ describe("[Unit] Assertion.test.ts", () => {
           assert.deepStrictEqual(test.not.toBeSame(expected), test);
         });
       });
+    });
+  });
+
+  describe(".toBeSameAs", () => {
+    it("aliases .toBeSame(..) method", () => {
+      const test = new StringAssertion("Foo");
+      const spy = Sinon.spy(test, "toBeSame");
+
+      test.toBeSameAs("Foo");
+
+      Sinon.assert.calledWithExactly(spy, "Foo");
+    });
+  });
+
+  describe(".toBe", () => {
+    it("aliases .toBeSame(..) method", () => {
+      const test = new StringAssertion("Foo");
+      const spy = Sinon.spy(test, "toBeSame");
+
+      test.toBe("Foo");
+
+      Sinon.assert.calledWithExactly(spy, "Foo");
     });
   });
 
@@ -492,7 +513,9 @@ describe("[Unit] Assertion.test.ts", () => {
 
           assert.deepStrictEqual(test.toBeOfType(expected), test);
           assert.throws(() => test.not.toBeOfType(expected), {
-            message: `Expected <${prettify(value)}> NOT to be of type <${expected}>`,
+            message: `Expected <${prettify(
+              value
+            )}> NOT to be of type <${expected}>`,
             name: AssertionError.name,
           });
         });
@@ -517,7 +540,9 @@ describe("[Unit] Assertion.test.ts", () => {
           const test = new Assertion(value);
 
           assert.throws(() => test.toBeOfType(expected), {
-            message: `Expected <${prettify(value)}> to be of type <${expected}>`,
+            message: `Expected <${prettify(
+              value
+            )}> to be of type <${expected}>`,
             name: AssertionError.name,
           });
           assert.deepStrictEqual(test.not.toBeOfType(expected), test);
@@ -531,7 +556,10 @@ describe("[Unit] Assertion.test.ts", () => {
       it("returns a new instance of the assertion passed to the type factory", () => {
         const test = new Assertion("foo");
 
-        assert.deepStrictEqual(test.asType(TypeFactories.String), new StringAssertion("foo"));
+        assert.deepStrictEqual(
+          test.asType(TypeFactories.String),
+          new StringAssertion("foo")
+        );
       });
     });
 
@@ -551,7 +579,8 @@ describe("[Unit] Assertion.test.ts", () => {
         const test = new Assertion("foo");
 
         assert.throws(() => test.not.asType(TypeFactories.String), {
-          message: "Unsupported operation. The `.not` modifier is not allowed on `.asType(..)` method",
+          message:
+            "Unsupported operation. The `.not` modifier is not allowed on `.asType(..)` method",
           name: UnsupportedOperationError.name,
         });
       });

--- a/packages/core/test/lib/Assertion.test.ts
+++ b/packages/core/test/lib/Assertion.test.ts
@@ -135,7 +135,7 @@ describe("[Unit] Assertion.test.ts", () => {
       });
     });
 
-    [undefined, null].forEach((value) => {
+    [undefined, null].forEach(value => {
       context(`when the value is ${value}`, () => {
         it("throws an assertion error", () => {
           const test = new Assertion(value);
@@ -230,7 +230,7 @@ describe("[Unit] Assertion.test.ts", () => {
 
   describe(".toBeTruthy", () => {
     context("when the value is truthy", () => {
-      TRUTHY_VALUES.forEach((value) => {
+      TRUTHY_VALUES.forEach(value => {
         it(`[${truthyAsText(value)}] returns the assertion instance`, () => {
           const test = new Assertion(value);
 
@@ -244,7 +244,7 @@ describe("[Unit] Assertion.test.ts", () => {
     });
 
     context("when the value is NOT truthy", () => {
-      FALSY_VALUES.forEach((value) => {
+      FALSY_VALUES.forEach(value => {
         it(`[${falsyAsText(value)}] throws an assertion error`, () => {
           const test = new Assertion(value);
 
@@ -260,7 +260,7 @@ describe("[Unit] Assertion.test.ts", () => {
 
   describe(".toBeFalsy", () => {
     context("when the value is falsy", () => {
-      FALSY_VALUES.forEach((value) => {
+      FALSY_VALUES.forEach(value => {
         it(`[${falsyAsText(value)}] returns the assertion instance`, () => {
           const test = new Assertion(value);
 
@@ -274,7 +274,7 @@ describe("[Unit] Assertion.test.ts", () => {
     });
 
     context("when the value NOT falsy", () => {
-      TRUTHY_VALUES.forEach((value) => {
+      TRUTHY_VALUES.forEach(value => {
         it(`[${truthyAsText(value)}] throws an assertion error`, () => {
           const test = new Assertion(value);
 
@@ -372,7 +372,7 @@ describe("[Unit] Assertion.test.ts", () => {
             assert.deepStrictEqual(test.not.toBeEqual(expected), test);
           });
         });
-      }
+      },
     );
   });
 
@@ -514,7 +514,7 @@ describe("[Unit] Assertion.test.ts", () => {
           assert.deepStrictEqual(test.toBeOfType(expected), test);
           assert.throws(() => test.not.toBeOfType(expected), {
             message: `Expected <${prettify(
-              value
+              value,
             )}> NOT to be of type <${expected}>`,
             name: AssertionError.name,
           });
@@ -541,7 +541,7 @@ describe("[Unit] Assertion.test.ts", () => {
 
           assert.throws(() => test.toBeOfType(expected), {
             message: `Expected <${prettify(
-              value
+              value,
             )}> to be of type <${expected}>`,
             name: AssertionError.name,
           });
@@ -558,7 +558,7 @@ describe("[Unit] Assertion.test.ts", () => {
 
         assert.deepStrictEqual(
           test.asType(TypeFactories.String),
-          new StringAssertion("foo")
+          new StringAssertion("foo"),
         );
       });
     });

--- a/packages/core/test/lib/Assertion.test.ts
+++ b/packages/core/test/lib/Assertion.test.ts
@@ -15,9 +15,23 @@ const HERO = {
 
 const THINGS = [1, "foo", false];
 
-const TRUTHY_VALUES = [true, 1, "foo", {}, [], new Date()];
+const TRUTHY_VALUES = [
+  true,
+  1,
+  "foo",
+  { },
+  [],
+  new Date(),
+];
 
-const FALSY_VALUES = [null, undefined, 0, "", false, NaN];
+const FALSY_VALUES = [
+  null,
+  undefined,
+  0,
+  "",
+  false,
+  NaN,
+];
 
 const TODAY = new Date("2021-12-10T00:00:00.000Z");
 
@@ -42,6 +56,7 @@ const BASE_DIFFS = [
 ];
 
 class Car {
+
   private readonly model: string;
 
   public constructor(model: string) {
@@ -53,7 +68,7 @@ class Car {
   }
 }
 
-function truthyAsText(value: (typeof TRUTHY_VALUES)[number]): string {
+function truthyAsText(value: typeof TRUTHY_VALUES[number]): string {
   if (Array.isArray(value) && value.length === 0) {
     return "Empty array";
   }
@@ -69,8 +84,10 @@ function truthyAsText(value: (typeof TRUTHY_VALUES)[number]): string {
   return String(value);
 }
 
-function falsyAsText(value: (typeof FALSY_VALUES)[number]): string {
-  return value === "" ? '""' : `${value}`;
+function falsyAsText(value: typeof FALSY_VALUES[number]): string {
+  return value === ""
+    ? '""'
+    : `${value}`;
 }
 
 describe("[Unit] Assertion.test.ts", () => {
@@ -332,7 +349,8 @@ describe("[Unit] Assertion.test.ts", () => {
         ["deep-object", { ...HERO, opts: THINGS }, { ...HERO, opts: THINGS }],
         ["deep-array", [...THINGS, { x: HERO }], [...THINGS, { x: HERO }]],
         ["date", TODAY, new Date(TODAY.toISOString())],
-      ].forEach(([type, actual, expected]) => {
+      ]
+      .forEach(([type, actual, expected]) => {
         it(`[${type}] returns the assertion instance`, () => {
           const test = new Assertion(actual);
 
@@ -345,35 +363,29 @@ describe("[Unit] Assertion.test.ts", () => {
       });
     });
 
-    context(
-      "when the value is NOT referentially, NOR shallow, NOR deep equal",
-      () => {
-        [
-          ...BASE_DIFFS,
-          ["NaN", NaN, 5],
-          ["object-ref", HERO, { ...HERO, x: 1 }],
-          ["array-ref", THINGS, [...THINGS, "banana"]],
-          ["shallow-object", { ...HERO }, { ...HERO, foo: { x: 1 } }],
-          ["shallow-array", [1, 2, 3], [1, 2, 3, { x: 4 }]],
-          [
-            "deep-object",
-            { ...HERO, opts: { x: 1 } },
-            { ...HERO, opts: { x: 2 } },
-          ],
-          ["deep-array", [...THINGS, { x: 1 }], [...THINGS, { x: 2 }]],
-        ].forEach(([type, actual, expected]) => {
-          it(`[${type}] throws an assertion error`, () => {
-            const test = new Assertion(actual);
+    context("when the value is NOT referentially, NOR shallow, NOR deep equal", () => {
+      [
+        ...BASE_DIFFS,
+        ["NaN", NaN, 5],
+        ["object-ref", HERO, { ...HERO, x: 1 }],
+        ["array-ref", THINGS, [...THINGS, "banana"]],
+        ["shallow-object", { ...HERO }, { ...HERO, foo: { x: 1 } }],
+        ["shallow-array", [1, 2, 3], [1, 2, 3, { x: 4 }]],
+        ["deep-object", { ...HERO, opts: { x: 1 } }, { ...HERO, opts: { x: 2 } }],
+        ["deep-array", [...THINGS, { x: 1 }], [...THINGS, { x: 2 }]],
+      ]
+      .forEach(([type, actual, expected]) => {
+        it(`[${type}] throws an assertion error`, () => {
+          const test = new Assertion(actual);
 
-            assert.throws(() => test.toBeEqual(expected), {
-              message: "Expected both values to be deep equal",
-              name: AssertionError.name,
-            });
-            assert.deepStrictEqual(test.not.toBeEqual(expected), test);
+          assert.throws(() => test.toBeEqual(expected), {
+            message: "Expected both values to be deep equal",
+            name: AssertionError.name,
           });
+          assert.deepStrictEqual(test.not.toBeEqual(expected), test);
         });
-      },
-    );
+      });
+    });
   });
 
   describe(".toBeSimilar", () => {
@@ -383,7 +395,8 @@ describe("[Unit] Assertion.test.ts", () => {
         ["NaN", NaN, NaN], // Shallow equality has a workaround for `NaN === NaN`
         ["shallow-object", HERO, { name: "Batman", realName: "Bruce Wayne" }],
         ["shallow-array", THINGS, [1, "foo", false]],
-      ].forEach(([valueType, expected, actual]) => {
+      ]
+      .forEach(([valueType, expected, actual]) => {
         it(`[${valueType}] returns the assertion instance`, () => {
           const test = new Assertion(actual);
 
@@ -402,19 +415,12 @@ describe("[Unit] Assertion.test.ts", () => {
         ["NaN", NaN, 5],
         ["object-ref", HERO, { ...HERO, x: 1 }],
         ["array-ref", THINGS, [...THINGS, "banana"]],
-        [
-          "shallow-object",
-          { ...HERO, opt: [...THINGS] },
-          { ...HERO, opt: [...THINGS] },
-        ],
+        ["shallow-object", { ...HERO, opt: [...THINGS] }, { ...HERO, opt: [...THINGS] }],
         ["shallow-array", [1, 2, { hero: HERO }], [1, 2, { hero: HERO }]],
-        [
-          "deep-object",
-          { ...HERO, opts: { x: THINGS } },
-          { ...HERO, opts: { x: THINGS } },
-        ],
+        ["deep-object", { ...HERO, opts: { x: THINGS } }, { ...HERO, opts: { x: THINGS } }],
         ["deep-array", [...THINGS, { x: 1 }], [...THINGS, { x: 1 }]],
-      ].forEach(([type, actual, expected]) => {
+      ]
+      .forEach(([type, actual, expected]) => {
         it(`[${type}] throws an assertion error`, () => {
           const test = new Assertion(actual);
 
@@ -451,13 +457,10 @@ describe("[Unit] Assertion.test.ts", () => {
         ["array-ref", [...THINGS], [...THINGS]],
         ["shallow-object", HERO, { name: "Batman", realName: "Bruce Wayne" }],
         ["shallow-array", THINGS, [1, "foo", false]],
-        [
-          "deep-object",
-          { ...HERO, opts: { x: THINGS } },
-          { ...HERO, opts: { x: THINGS } },
-        ],
+        ["deep-object", { ...HERO, opts: { x: THINGS } }, { ...HERO, opts: { x: THINGS } }],
         ["deep-array", [...THINGS, { x: 1 }], [...THINGS, { x: 1 }]],
-      ].forEach(([type, actual, expected]) => {
+      ]
+      .forEach(([type, actual, expected]) => {
         it(`[${type}] throws an assertion error`, () => {
           const test = new Assertion(actual);
 
@@ -513,9 +516,7 @@ describe("[Unit] Assertion.test.ts", () => {
 
           assert.deepStrictEqual(test.toBeOfType(expected), test);
           assert.throws(() => test.not.toBeOfType(expected), {
-            message: `Expected <${prettify(
-              value,
-            )}> NOT to be of type <${expected}>`,
+            message: `Expected <${prettify(value)}> NOT to be of type <${expected}>`,
             name: AssertionError.name,
           });
         });
@@ -540,9 +541,7 @@ describe("[Unit] Assertion.test.ts", () => {
           const test = new Assertion(value);
 
           assert.throws(() => test.toBeOfType(expected), {
-            message: `Expected <${prettify(
-              value,
-            )}> to be of type <${expected}>`,
+            message: `Expected <${prettify(value)}> to be of type <${expected}>`,
             name: AssertionError.name,
           });
           assert.deepStrictEqual(test.not.toBeOfType(expected), test);
@@ -556,10 +555,7 @@ describe("[Unit] Assertion.test.ts", () => {
       it("returns a new instance of the assertion passed to the type factory", () => {
         const test = new Assertion("foo");
 
-        assert.deepStrictEqual(
-          test.asType(TypeFactories.String),
-          new StringAssertion("foo"),
-        );
+        assert.deepStrictEqual(test.asType(TypeFactories.String), new StringAssertion("foo"));
       });
     });
 
@@ -579,8 +575,7 @@ describe("[Unit] Assertion.test.ts", () => {
         const test = new Assertion("foo");
 
         assert.throws(() => test.not.asType(TypeFactories.String), {
-          message:
-            "Unsupported operation. The `.not` modifier is not allowed on `.asType(..)` method",
+          message: "Unsupported operation. The `.not` modifier is not allowed on `.asType(..)` method",
           name: UnsupportedOperationError.name,
         });
       });


### PR DESCRIPTION
# Changes

Include `toBeSameAs` and `toBe` alias for `toBeSame`.

*NOTE:* My code formatter modified some files. Let me know if it's okay to keep it that way, otherwise I can revert that to keep only the necessary changes.﻿

Solves #108 

---
As part of [Stack Builders Inc.](https://www.stackbuilders.com/) Hacktoberfest 2023 event.
