### PR TITLE
fix(core): Allow arrays of plugins on usePlugin(..)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,11 +20,14 @@ export {
 };
 
 /**
- * Extends `@assertive-ts/core` with a local or 3rd-party plugin.
+ * Extends `@assertive-ts/core` with local or 3rd-party plugin(s).
  *
- * @param plugin the plugin to use to extend assertive-ts
+ * @param plugins a plugin or an array of plugins to use
  * @see {@link Plugin Plugin}
  */
-export function usePlugin<T, A extends Assertion<T>>(plugin: Plugin<T, A>): void {
-  config.addPlugin(plugin);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function usePlugin<P extends Plugin<any, Assertion<any>>>(plugins: P | P[]): void {
+  Array.isArray(plugins)
+    ? plugins.forEach(plugin => config.addPlugin(plugin))
+    : config.addPlugin(plugins);
 }

--- a/packages/core/src/lib/config/Config.ts
+++ b/packages/core/src/lib/config/Config.ts
@@ -1,8 +1,14 @@
 import { Assertion } from "../Assertion";
 
+/**
+ * A plugin object that can be used to extend the `expect(..)` function.
+ *
+ * @param T the type the plugin is meant for
+ * @param A the type of the assertion for `T`
+ */
 export interface Plugin<T, A extends Assertion<T>> {
   /**
-   * The `Assertion<T>` instance the plugin adds
+   * The assertion `A` constructor the plugin adds
    */
   Assertion: new(actual: T) => A;
   /**


### PR DESCRIPTION
Some plugins might consist of multiple assertion instances. These plugins might want to expose a single variable to be used by the `usePlugin(..)` function, so we need the argument so accept a single plugin (for backward compact) or an array of them.