### PR TITLE
chore(all): Use turbo to build all docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "check": "turbo check && yarn lint",
     "build": "turbo run build",
     "compile": "turbo run compile",
-    "docs": "yarn workspace @assertive-ts/core docs",
+    "docs": "turbo docs",
     "lint": "eslint .",
     "release": "turbo release --concurrency=1",
     "test": "turbo run test"

--- a/packages/core/.mocharc.json
+++ b/packages/core/.mocharc.json
@@ -5,5 +5,6 @@
   "require": [
     "ts-node/register",
     "test/hooks.ts"
-  ]
+  ],
+  "spec": ["test/**/*.test.*"]
 }

--- a/packages/core/.releaserc.json
+++ b/packages/core/.releaserc.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/semantic-release",
-  "branches": [
-    "main"
-  ],
+  "branches": ["main"],
   "plugins": [
     ["@semantic-release/commit-analyzer", {
       "releaseRules": [{ "scope": "!core", "release": false }]

--- a/packages/sinon/.mocharc.json
+++ b/packages/sinon/.mocharc.json
@@ -5,5 +5,6 @@
   "require": [
     "ts-node/register",
     "test/hooks.ts"
-  ]
+  ],
+  "spec": ["test/**/*.test.*"]
 }

--- a/packages/sinon/.releaserc.json
+++ b/packages/sinon/.releaserc.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/semantic-release",
-  "branches": [
-    "main"
-  ],
+  "branches": ["main"],
   "plugins": [
     ["@semantic-release/commit-analyzer", {
       "releaseRules": [{ "scope": "!sinon", "release": false }]

--- a/turbo.json
+++ b/turbo.json
@@ -14,6 +14,11 @@
       "dependsOn": ["^build"],
       "outputs": ["build/**"]
     },
+    "docs": {
+      "dependsOn": ["^build"],
+      "inputs": ["src/**", "typings/**"],
+      "outputs": ["docs/*/build/**"]
+    },
     "release": {
       "cache": false,
       "dependsOn": ["^build"]


### PR DESCRIPTION
Fix the main script to run the `docs` command using turbo so all docs are generated on deploy.