### PR TITLE
chore(all): Allow scope `all` for all packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ MIT, see [the LICENSE file](LICENSE).
 
 ## Contributing
 
-Do you want to contribute to this project? Please take a look at our [contributing guideline](/docs/CONTRIBUTING.md) to know how you can help us build it.
+Do you want to contribute to this project? Please take a look at our [contributing guidelines](/docs/CONTRIBUTING.md) to know how you can help us build it. You can also check the [development guide](/docs/development.md) for information about local setup and the release process.
 
 ---
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,11 +1,13 @@
-## Development
+# Development
 
 To setup your local environment follow the next steps.
 
-### Requirements
+## Requirements
 
 * Latest [Yarn Classic](https://classic.yarnpkg.com)
 * NodeJS (Use version set on [.nvmrc](https://github.com/stackbuilders/assertive-ts/blob/master/.nvmrc))
+
+## Useful commands
 
 ### Install dependencies
 
@@ -30,3 +32,17 @@ yarn lint
 ```console
 yarn test
 ```
+
+## Release process
+
+The release process is automated by [semantic-release](https://semantic-release.gitbook.io/semantic-release/), so please make sure that the first commit of any PR follows the [Conventional Commits standard](https://www.conventionalcommits.org/). Take a look at semantic-release documentation if you're not sure what type of commit you should use.
+
+### Scopes
+
+Scopes are optional on Conventional Commits, but we take advantange of them to specify the package a change is aimed for. The table below describes the the available scopes and what package they affect:
+
+| Scope   | Package               | Commit example                   |
+| :-----: | :-------------------: | -------------------------------- |
+| `all`   | All packages          | feat(all): Upadate TypeScript    |
+| `core`  | `@assertive-ts/core`  | fix(core): Boolean assertion bug |
+| `sinon` | `@assertive-ts/sinon` | fix(sinon): Spy assertion bug    |

--- a/packages/core/.releaserc.json
+++ b/packages/core/.releaserc.json
@@ -3,7 +3,10 @@
   "branches": ["main"],
   "plugins": [
     ["@semantic-release/commit-analyzer", {
-      "releaseRules": [{ "scope": "!core", "release": false }]
+      "releaseRules": [
+        { "scope": "!all", "release": false },
+        { "scope": "!core", "release": false }
+      ]
     }],
     "@semantic-release/release-notes-generator",
     "semantic-release-yarn",

--- a/packages/dom/.releaserc.json
+++ b/packages/dom/.releaserc.json
@@ -3,7 +3,10 @@
   "branches": ["main"],
   "plugins": [
     ["@semantic-release/commit-analyzer", {
-      "releaseRules": [{ "scope": "!dom", "release": false }]
+      "releaseRules": [
+        { "scope": "!all", "release": false },
+        { "scope": "!dom", "release": false }
+      ]
     }],
     "@semantic-release/release-notes-generator",
     "semantic-release-yarn",

--- a/packages/sinon/.releaserc.json
+++ b/packages/sinon/.releaserc.json
@@ -3,7 +3,10 @@
   "branches": ["main"],
   "plugins": [
     ["@semantic-release/commit-analyzer", {
-      "releaseRules": [{ "scope": "!sinon", "release": false }]
+      "releaseRules": [
+        { "scope": "!all", "release": false },
+        { "scope": "!sinon", "release": false }
+      ]
     }],
     "@semantic-release/release-notes-generator",
     "semantic-release-yarn",


### PR DESCRIPTION
Adding the scope `all` to all packages allows us to push commits that can cause a release in all packages.