### PR TITLE
feat(native): Add toHaveTextContent matcher

### DIFF
--- a/packages/native/src/lib/ElementAssertion.ts
+++ b/packages/native/src/lib/ElementAssertion.ts
@@ -243,6 +243,19 @@ export class ElementAssertion extends Assertion<ReactTestInstance> {
     });
   }
 
+  /**
+   * Check if the element has text content matching the provided string, RegExp, or function.
+   *
+   * @example
+   * ```
+   * expect(element).toHaveTextContent("Hello World");
+   * expect(element).toHaveTextContent(/Hello/);
+   * expect(element).toHaveTextContent(text => text.startsWith("Hello"));
+   * ```
+   *
+   * @param text - The text to check for.
+   * @returns the assertion instance
+   */
   public toHaveTextContent(text: string | RegExp | ((text: string) => boolean)): this {
     const actualTextContent = this.getTextContent(this.actual);
     const matchesText = textMatches(actualTextContent, text);

--- a/packages/native/src/lib/ElementAssertion.ts
+++ b/packages/native/src/lib/ElementAssertion.ts
@@ -2,8 +2,14 @@ import { Assertion, AssertionError } from "@assertive-ts/core";
 import { get } from "dot-prop-immutable";
 import { ReactTestInstance } from "react-test-renderer";
 
-import { AssertiveStyle, TestableTextMatcher, WithTextContent } from "./helpers/types";
-import { instanceToString, isEmpty, getFlattenedStyle, styleToString, testableTextMatcherToString, textMatches } from "./helpers/helpers";
+import {
+  instanceToString,
+  isEmpty,
+  getFlattenedStyle,
+  styleToString,
+  textMatches,
+} from "./helpers/helpers";
+import { AssertiveStyle, TestableTextMatcher, TextContent } from "./helpers/types";
 
 export class ElementAssertion extends Assertion<ReactTestInstance> {
   public constructor(actual: ReactTestInstance) {
@@ -223,7 +229,7 @@ export class ElementAssertion extends Assertion<ReactTestInstance> {
     const flattenedStyle = getFlattenedStyle(style);
 
     const hasStyle = Object.keys(flattenedStyle)
-                           .every(key => flattenedElementStyle[key] === flattenedStyle[key]);
+      .every(key => flattenedElementStyle[key] === flattenedStyle[key]);
 
     const error = new AssertionError({
       actual: this.actual,
@@ -263,14 +269,14 @@ export class ElementAssertion extends Assertion<ReactTestInstance> {
     const error = new AssertionError({
       actual: this.actual,
       message: `Expected element ${this.toString()} to have text content matching '` +
-        `${testableTextMatcherToString(text)}'.`,
+        `${text.toString()}'.`,
     });
 
     const invertedError = new AssertionError({
       actual: this.actual,
       message:
-      `Expected element ${this.toString()} NOT to have text content matching '` +
-      `${testableTextMatcherToString(text)}'.`,
+        `Expected element ${this.toString()} NOT to have text content matching '` +
+        `${text.toString()}'.`,
     });
 
     return this.execute({
@@ -296,7 +302,7 @@ export class ElementAssertion extends Assertion<ReactTestInstance> {
     return this.collectText(element).join(" ");
   }
 
-  private collectText = (element: WithTextContent): string[] => {
+  private collectText = (element: TextContent): string[] => {
     if (typeof element === "string") {
       return [element];
     }
@@ -305,8 +311,8 @@ export class ElementAssertion extends Assertion<ReactTestInstance> {
       return element.flatMap(child => this.collectText(child));
     }
 
-    if (element && typeof element === "object" && "props" in element) {
-      const value = element.props?.value as WithTextContent;
+    if (element && (typeof element === "object" && "props" in element)) {
+      const value = element.props?.value as TextContent;
       if (typeof value === "string") {
         return [value];
       }
@@ -332,10 +338,10 @@ export class ElementAssertion extends Assertion<ReactTestInstance> {
     }
 
     return (
-        get(element, "props.aria-disabled")
-        || get(element, "props.disabled", false)
-        || get(element, "props.accessibilityState.disabled", false)
-        || get<ReactTestInstance, string[]>(element, "props.accessibilityStates", []).includes("disabled")
+      get(element, "props.aria-disabled")
+      || get(element, "props.disabled", false)
+      || get(element, "props.accessibilityState.disabled", false)
+      || get<ReactTestInstance, string[]>(element, "props.accessibilityStates", []).includes("disabled")
     );
   }
 

--- a/packages/native/src/lib/helpers/helpers.ts
+++ b/packages/native/src/lib/helpers/helpers.ts
@@ -31,3 +31,39 @@ export function instanceToString(instance: ReactTestInstance | null): string {
 
   return `<${instance.type.toString()} ... />`;
 }
+
+/**
+ * Checks if a text matches a given matcher.
+ *  
+ * @param text - The text to check.
+ * @param matcher - The matcher to use for comparison. It can be a string, RegExp, or a function.
+ * @returns `true` if the text matches the matcher, `false` otherwise.
+ * @throws Error if the matcher is not a string, RegExp, or function.
+ * @example
+ * ```ts
+ * textMatches("Hello World", "Hello World"); // true
+ * textMatches("Hello World", /Hello/); // true
+ * textMatches("Hello World", (text) => text.startsWith("Hello")); // true
+ * textMatches("Hello World", "Goodbye"); // false
+ * textMatches("Hello World", /Goodbye/); // false
+ * textMatches("Hello World", (text) => text.startsWith("Goodbye")); // false
+ * ```
+ */
+export function textMatches(
+  text: string,
+  matcher: string | RegExp | ((text: string) => boolean),
+): boolean {
+  if (typeof matcher === "string") {
+    return text.includes(matcher);
+  }
+
+  if (matcher instanceof RegExp) {
+    return matcher.test(text);
+  }
+
+  if (typeof matcher === "function") {
+    return matcher(text);
+  }
+
+  throw new Error("Matcher must be a string, RegExp, or function.");
+}

--- a/packages/native/src/lib/helpers/helpers.ts
+++ b/packages/native/src/lib/helpers/helpers.ts
@@ -1,5 +1,7 @@
 import { ReactTestInstance } from "react-test-renderer";
 
+import { TestableTextMatcher } from "./types";
+
 /**
  * Checks if a value is empty.
  *
@@ -33,10 +35,33 @@ export function instanceToString(instance: ReactTestInstance | null): string {
 }
 
 /**
+ * Converts a TestableTextMatcher to a string representation.
+ *
+ * @param matcher - The matcher to convert.
+ * @returns A string representation of the matcher.
+ * @throws Error if the matcher is not a string, RegExp, or function.
+ */
+export function testableTextMatcherToString(matcher: TestableTextMatcher): string {
+  if (typeof matcher === "string") {
+    return `String: "${matcher}"`;
+  }
+
+  if (matcher instanceof RegExp) {
+    return `RegExp: ${matcher.toString()}`;
+  }
+
+  if (typeof matcher === "function") {
+    return `Function: ${matcher.toString()}`;
+  }
+
+  throw new Error("Matcher must be a string, RegExp, or function.");
+}
+
+/**
  * Checks if a text matches a given matcher.
- *  
+ *
  * @param text - The text to check.
- * @param matcher - The matcher to use for comparison. It can be a string, RegExp, or a function.
+ * @param matcher - The matcher to use for comparison.
  * @returns `true` if the text matches the matcher, `false` otherwise.
  * @throws Error if the matcher is not a string, RegExp, or function.
  * @example
@@ -51,7 +76,7 @@ export function instanceToString(instance: ReactTestInstance | null): string {
  */
 export function textMatches(
   text: string,
-  matcher: string | RegExp | ((text: string) => boolean),
+  matcher: TestableTextMatcher,
 ): boolean {
   if (typeof matcher === "string") {
     return text.includes(matcher);

--- a/packages/native/src/lib/helpers/helpers.ts
+++ b/packages/native/src/lib/helpers/helpers.ts
@@ -36,29 +36,6 @@ export function instanceToString(instance: ReactTestInstance | null): string {
 }
 
 /**
- * Converts a TestableTextMatcher to a string representation.
- *
- * @param matcher - The matcher to convert.
- * @returns A string representation of the matcher.
- * @throws Error if the matcher is not a string, RegExp, or function.
- */
-export function testableTextMatcherToString(matcher: TestableTextMatcher): string {
-  if (typeof matcher === "string") {
-    return `String: "${matcher}"`;
-  }
-
-  if (matcher instanceof RegExp) {
-    return `RegExp: ${matcher.toString()}`;
-  }
-
-  if (typeof matcher === "function") {
-    return `Function: ${matcher.toString()}`;
-  }
-
-  throw new Error("Matcher must be a string, RegExp, or function.");
-}
-
-/**
  * Checks if a text matches a given matcher.
  *
  * @param text - The text to check.

--- a/packages/native/src/lib/helpers/types.ts
+++ b/packages/native/src/lib/helpers/types.ts
@@ -1,4 +1,5 @@
 import { ImageStyle, StyleProp, TextStyle, ViewStyle } from "react-native";
+import { ReactTestInstance } from "react-test-renderer";
 
 /**
  * Type representing a style that can be applied to a React Native component.
@@ -17,3 +18,17 @@ export type AssertiveStyle = StyleProp<Style>;
  * It is a record where the keys are strings and the values can be of any type.
  */
 export type StyleObject = Record<string, unknown>;
+
+/**
+ * Type representing a matcher for text in tests.
+ *
+ * It can be a string, a regular expression, or a function that
+ * takes a string and returns a boolean.
+ */
+export type TestableTextMatcher = string | RegExp | ((text: string) => boolean);
+
+/**
+ * Type representing a value that can be used to match text content in tests.
+ * It can be a string, a ReactTestInstance, or an array of ReactTestInstances.
+ */
+export type WithTextContent = string | ReactTestInstance | ReactTestInstance[];

--- a/packages/native/src/lib/helpers/types.ts
+++ b/packages/native/src/lib/helpers/types.ts
@@ -31,4 +31,4 @@ export type TestableTextMatcher = string | RegExp | ((text: string) => boolean);
  * Type representing a value that can be used to match text content in tests.
  * It can be a string, a ReactTestInstance, or an array of ReactTestInstances.
  */
-export type WithTextContent = string | ReactTestInstance | ReactTestInstance[];
+export type TextContent = string | ReactTestInstance | ReactTestInstance[];

--- a/packages/native/test/lib/ElementAssertion.test.tsx
+++ b/packages/native/test/lib/ElementAssertion.test.tsx
@@ -527,57 +527,57 @@ describe("[Unit] ElementAssertion.test.ts", () => {
     context("when the element contains the target text", () => {
       it("returns the assertion instance", () => {
         const element = render(
-          <Text testID="id">Hello World</Text>,
+          <Text testID="id">{"Hello World"}</Text>,
         );
         const test = new ElementAssertion(element.getByTestId("id"));
 
         expect(test.toHaveTextContent("Hello World")).toBe(test);
         expect(() => test.not.toHaveTextContent("Hello World"))
           .toThrowError(AssertionError)
-          .toHaveMessage("Expected element <Text ... /> NOT to have text content matching 'Hello World'.");
+          .toHaveMessage("Expected element <Text ... /> NOT to have text content matching 'String: \"Hello World\"'.");
       });
     });
 
     context("when the element does NOT contain the target text", () => {
       it("throws an error", () => {
         const element = render(
-          <Text testID="id">Hello World</Text>,
+          <Text testID="id">{"Hello World"}</Text>,
         );
         const test = new ElementAssertion(element.getByTestId("id"));
 
         expect(test.not.toHaveTextContent("Goodbye World")).toBeEqual(test);
         expect(() => test.toHaveTextContent("Goodbye World"))
           .toThrowError(AssertionError)
-          .toHaveMessage("Expected element <Text ... /> to have text content matching 'Goodbye World'.");
+          .toHaveMessage("Expected element <Text ... /> to have text content matching 'String: \"Goodbye World\"'.");
       });
     });
 
     context("when the element contains the target text with a RegExp", () => {
       it("returns the assertion instance", () => {
         const element = render(
-          <Text testID="id">Hello World</Text>,
+          <Text testID="id">{"Hello World"}</Text>,
         );
         const test = new ElementAssertion(element.getByTestId("id"));
 
         expect(test.toHaveTextContent(/Hello/)).toBe(test);
         expect(() => test.not.toHaveTextContent(/Hello/))
           .toThrowError(AssertionError)
-          .toHaveMessage("Expected element <Text ... /> NOT to have text content matching '/Hello/'.");
+          .toHaveMessage("Expected element <Text ... /> NOT to have text content matching 'RegExp: /Hello/'.");
       });
     });
 
     context("when the element does NOT contain the target text with a RegExp", () => {
       it("throws an error", () => {
         const element = render(
-          <Text testID="id">Hello World</Text>,
+          <Text testID="id">{"Hello World"}</Text>,
         );
         const test = new ElementAssertion(element.getByTestId("id"));
 
         expect(test.not.toHaveTextContent(/Goodbye/)).toBeEqual(test);
         expect(() => test.toHaveTextContent(/Goodbye/))
           .toThrowError(AssertionError)
-          .toHaveMessage("Expected element <Text ... /> to have text content matching '/Goodbye/'.");
-      })
+          .toHaveMessage("Expected element <Text ... /> to have text content matching 'RegExp: /Goodbye/'.");
+      });
     });
 
     context("when the eleme contains the target text within a child element", () => {
@@ -585,10 +585,10 @@ describe("[Unit] ElementAssertion.test.ts", () => {
         const element = render(
           <View testID="id">
             <View>
-              <Text>Test 1</Text>
+              <Text>{"Test 1"}</Text>
               <View>
-                <Text>Test 2</Text>
-                <Text>Hello World</Text>
+                <Text>{"Test 2"}</Text>
+                <Text>{"Hello World"}</Text>
               </View>
             </View>
           </View>,
@@ -597,7 +597,7 @@ describe("[Unit] ElementAssertion.test.ts", () => {
         expect(test.toHaveTextContent("Hello World")).toBe(test);
         expect(() => test.not.toHaveTextContent("Hello World"))
           .toThrowError(AssertionError)
-          .toHaveMessage("Expected element <View ... /> NOT to have text content matching 'Hello World'.");
+          .toHaveMessage("Expected element <View ... /> NOT to have text content matching 'String: \"Hello World\"'.");
       });
     });
 
@@ -606,10 +606,10 @@ describe("[Unit] ElementAssertion.test.ts", () => {
         const element = render(
           <View testID="id">
             <View>
-              <Text>Test 1</Text>
+              <Text>{"Test 1"}</Text>
               <View>
-                <Text>Test 2</Text>
-                <Text>Hello World</Text>
+                <Text>{"Test 2"}</Text>
+                <Text>{"Hello World"}</Text>
               </View>
             </View>
           </View>,
@@ -618,35 +618,41 @@ describe("[Unit] ElementAssertion.test.ts", () => {
         expect(test.not.toHaveTextContent("Goodbye World")).toBeEqual(test);
         expect(() => test.toHaveTextContent("Goodbye World"))
           .toThrowError(AssertionError)
-          .toHaveMessage("Expected element <View ... /> to have text content matching 'Goodbye World'.");
+          .toHaveMessage("Expected element <View ... /> to have text content matching 'String: \"Goodbye World\"'.");
       });
     });
 
     context("when the element contains the target text with a function matcher", () => {
       it("returns the assertion instance", () => {
         const element = render(
-          <Text testID="id">Hello World</Text>,
+          <Text testID="id">{"Hello World"}</Text>,
         );
         const test = new ElementAssertion(element.getByTestId("id"));
 
-        expect(test.toHaveTextContent((text) => text.startsWith("Hello"))).toBe(test);
-        expect(() => test.not.toHaveTextContent((text) => text.startsWith("Hello")))
+        expect(test.toHaveTextContent(text => text.startsWith("Hello"))).toBe(test);
+        expect(() => test.not.toHaveTextContent(text => text.startsWith("Hello")))
           .toThrowError(AssertionError)
-          .toHaveMessage("Expected element <Text ... /> NOT to have text content matching '(text) => text.startsWith(\"Hello\")'.");
+          .toHaveMessage(
+            "Expected element <Text ... /> NOT to have text content matching " +
+            "'Function: text => text.startsWith(\"Hello\")'.",
+          );
       });
     });
 
     context("when the element does NOT contain the target text with a function matcher", () => {
       it("throws an error", () => {
         const element = render(
-          <Text testID="id">Hello World</Text>,
+          <Text testID="id">{"Hello World"}</Text>,
         );
         const test = new ElementAssertion(element.getByTestId("id"));
 
-        expect(test.not.toHaveTextContent((text) => text.startsWith("Goodbye"))).toBeEqual(test);
-        expect(() => test.toHaveTextContent((text) => text.startsWith("Goodbye")))
+        expect(test.not.toHaveTextContent(text => text.startsWith("Goodbye"))).toBeEqual(test);
+        expect(() => test.toHaveTextContent(text => text.startsWith("Goodbye")))
           .toThrowError(AssertionError)
-          .toHaveMessage("Expected element <Text ... /> to have text content matching '(text) => text.startsWith(\"Goodbye\")'.");
+          .toHaveMessage(
+            "Expected element <Text ... /> to have text content matching " +
+            "'Function: text => text.startsWith(\"Goodbye\")'.",
+          );
       });
     });
 
@@ -660,7 +666,7 @@ describe("[Unit] ElementAssertion.test.ts", () => {
         expect(test.not.toHaveTextContent("Hello World")).toBeEqual(test);
         expect(() => test.toHaveTextContent("Hello World"))
           .toThrowError(AssertionError)
-          .toHaveMessage("Expected element <View ... /> to have text content matching 'Hello World'.");
+          .toHaveMessage("Expected element <View ... /> to have text content matching 'String: \"Hello World\"'.");
       });
     });
 
@@ -674,7 +680,7 @@ describe("[Unit] ElementAssertion.test.ts", () => {
         expect(test.not.toHaveTextContent(/Hello/)).toBeEqual(test);
         expect(() => test.toHaveTextContent(/Hello/))
           .toThrowError(AssertionError)
-          .toHaveMessage("Expected element <View ... /> to have text content matching '/Hello/'.");
+          .toHaveMessage("Expected element <View ... /> to have text content matching 'RegExp: /Hello/'.");
       });
     });
 
@@ -685,10 +691,13 @@ describe("[Unit] ElementAssertion.test.ts", () => {
         );
         const test = new ElementAssertion(element.getByTestId("id"));
 
-        expect(test.not.toHaveTextContent((text) => text.startsWith("Hello"))).toBeEqual(test);
-        expect(() => test.toHaveTextContent((text) => text.startsWith("Hello")))
+        expect(test.not.toHaveTextContent(text => text.startsWith("Hello"))).toBeEqual(test);
+        expect(() => test.toHaveTextContent(text => text.startsWith("Hello")))
           .toThrowError(AssertionError)
-          .toHaveMessage("Expected element <View ... /> to have text content matching '(text) => text.startsWith(\"Hello\")'.");
+          .toHaveMessage(
+            "Expected element <View ... /> to have text content matching " +
+            "'Function: text => text.startsWith(\"Hello\")'.",
+          );
       });
     });
   });

--- a/packages/native/test/lib/ElementAssertion.test.tsx
+++ b/packages/native/test/lib/ElementAssertion.test.tsx
@@ -522,4 +522,174 @@ describe("[Unit] ElementAssertion.test.ts", () => {
       });
     });
   });
+
+  describe(".toHaveTextContent", () => {
+    context("when the element contains the target text", () => {
+      it("returns the assertion instance", () => {
+        const element = render(
+          <Text testID="id">Hello World</Text>,
+        );
+        const test = new ElementAssertion(element.getByTestId("id"));
+
+        expect(test.toHaveTextContent("Hello World")).toBe(test);
+        expect(() => test.not.toHaveTextContent("Hello World"))
+          .toThrowError(AssertionError)
+          .toHaveMessage("Expected element <Text ... /> NOT to have text content matching 'Hello World'.");
+      });
+    });
+
+    context("when the element does NOT contain the target text", () => {
+      it("throws an error", () => {
+        const element = render(
+          <Text testID="id">Hello World</Text>,
+        );
+        const test = new ElementAssertion(element.getByTestId("id"));
+
+        expect(test.not.toHaveTextContent("Goodbye World")).toBeEqual(test);
+        expect(() => test.toHaveTextContent("Goodbye World"))
+          .toThrowError(AssertionError)
+          .toHaveMessage("Expected element <Text ... /> to have text content matching 'Goodbye World'.");
+      });
+    });
+
+    context("when the element contains the target text with a RegExp", () => {
+      it("returns the assertion instance", () => {
+        const element = render(
+          <Text testID="id">Hello World</Text>,
+        );
+        const test = new ElementAssertion(element.getByTestId("id"));
+
+        expect(test.toHaveTextContent(/Hello/)).toBe(test);
+        expect(() => test.not.toHaveTextContent(/Hello/))
+          .toThrowError(AssertionError)
+          .toHaveMessage("Expected element <Text ... /> NOT to have text content matching '/Hello/'.");
+      });
+    });
+
+    context("when the element does NOT contain the target text with a RegExp", () => {
+      it("throws an error", () => {
+        const element = render(
+          <Text testID="id">Hello World</Text>,
+        );
+        const test = new ElementAssertion(element.getByTestId("id"));
+
+        expect(test.not.toHaveTextContent(/Goodbye/)).toBeEqual(test);
+        expect(() => test.toHaveTextContent(/Goodbye/))
+          .toThrowError(AssertionError)
+          .toHaveMessage("Expected element <Text ... /> to have text content matching '/Goodbye/'.");
+      })
+    });
+
+    context("when the eleme contains the target text within a child element", () => {
+      it("returns the assertion instance", () => {
+        const element = render(
+          <View testID="id">
+            <View>
+              <Text>Test 1</Text>
+              <View>
+                <Text>Test 2</Text>
+                <Text>Hello World</Text>
+              </View>
+            </View>
+          </View>,
+        );
+        const test = new ElementAssertion(element.getByTestId("id"));
+        expect(test.toHaveTextContent("Hello World")).toBe(test);
+        expect(() => test.not.toHaveTextContent("Hello World"))
+          .toThrowError(AssertionError)
+          .toHaveMessage("Expected element <View ... /> NOT to have text content matching 'Hello World'.");
+      });
+    });
+
+    context("when the element does NOT contain the target text within a child element", () => {
+      it("throws an error", () => {
+        const element = render(
+          <View testID="id">
+            <View>
+              <Text>Test 1</Text>
+              <View>
+                <Text>Test 2</Text>
+                <Text>Hello World</Text>
+              </View>
+            </View>
+          </View>,
+        );
+        const test = new ElementAssertion(element.getByTestId("id"));
+        expect(test.not.toHaveTextContent("Goodbye World")).toBeEqual(test);
+        expect(() => test.toHaveTextContent("Goodbye World"))
+          .toThrowError(AssertionError)
+          .toHaveMessage("Expected element <View ... /> to have text content matching 'Goodbye World'.");
+      });
+    });
+
+    context("when the element contains the target text with a function matcher", () => {
+      it("returns the assertion instance", () => {
+        const element = render(
+          <Text testID="id">Hello World</Text>,
+        );
+        const test = new ElementAssertion(element.getByTestId("id"));
+
+        expect(test.toHaveTextContent((text) => text.startsWith("Hello"))).toBe(test);
+        expect(() => test.not.toHaveTextContent((text) => text.startsWith("Hello")))
+          .toThrowError(AssertionError)
+          .toHaveMessage("Expected element <Text ... /> NOT to have text content matching '(text) => text.startsWith(\"Hello\")'.");
+      });
+    });
+
+    context("when the element does NOT contain the target text with a function matcher", () => {
+      it("throws an error", () => {
+        const element = render(
+          <Text testID="id">Hello World</Text>,
+        );
+        const test = new ElementAssertion(element.getByTestId("id"));
+
+        expect(test.not.toHaveTextContent((text) => text.startsWith("Goodbye"))).toBeEqual(test);
+        expect(() => test.toHaveTextContent((text) => text.startsWith("Goodbye")))
+          .toThrowError(AssertionError)
+          .toHaveMessage("Expected element <Text ... /> to have text content matching '(text) => text.startsWith(\"Goodbye\")'.");
+      });
+    });
+
+    context("when the element has no text content", () => {
+      it("throws an error", () => {
+        const element = render(
+          <View testID="id" />,
+        );
+        const test = new ElementAssertion(element.getByTestId("id"));
+
+        expect(test.not.toHaveTextContent("Hello World")).toBeEqual(test);
+        expect(() => test.toHaveTextContent("Hello World"))
+          .toThrowError(AssertionError)
+          .toHaveMessage("Expected element <View ... /> to have text content matching 'Hello World'.");
+      });
+    });
+
+    context("when the element has no text content with a RegExp", () => {
+      it("throws an error", () => {
+        const element = render(
+          <View testID="id" />,
+        );
+        const test = new ElementAssertion(element.getByTestId("id"));
+
+        expect(test.not.toHaveTextContent(/Hello/)).toBeEqual(test);
+        expect(() => test.toHaveTextContent(/Hello/))
+          .toThrowError(AssertionError)
+          .toHaveMessage("Expected element <View ... /> to have text content matching '/Hello/'.");
+      });
+    });
+
+    context("when the element has no text content with a function matcher", () => {
+      it("throws an error", () => {
+        const element = render(
+          <View testID="id" />,
+        );
+        const test = new ElementAssertion(element.getByTestId("id"));
+
+        expect(test.not.toHaveTextContent((text) => text.startsWith("Hello"))).toBeEqual(test);
+        expect(() => test.toHaveTextContent((text) => text.startsWith("Hello")))
+          .toThrowError(AssertionError)
+          .toHaveMessage("Expected element <View ... /> to have text content matching '(text) => text.startsWith(\"Hello\")'.");
+      });
+    });
+  });
 });

--- a/packages/native/test/lib/ElementAssertion.test.tsx
+++ b/packages/native/test/lib/ElementAssertion.test.tsx
@@ -534,7 +534,7 @@ describe("[Unit] ElementAssertion.test.ts", () => {
         expect(test.toHaveTextContent("Hello World")).toBe(test);
         expect(() => test.not.toHaveTextContent("Hello World"))
           .toThrowError(AssertionError)
-          .toHaveMessage("Expected element <Text ... /> NOT to have text content matching 'String: \"Hello World\"'.");
+          .toHaveMessage("Expected element <Text ... /> NOT to have text content matching 'Hello World'.");
       });
     });
 
@@ -548,7 +548,7 @@ describe("[Unit] ElementAssertion.test.ts", () => {
         expect(test.not.toHaveTextContent("Goodbye World")).toBeEqual(test);
         expect(() => test.toHaveTextContent("Goodbye World"))
           .toThrowError(AssertionError)
-          .toHaveMessage("Expected element <Text ... /> to have text content matching 'String: \"Goodbye World\"'.");
+          .toHaveMessage("Expected element <Text ... /> to have text content matching 'Goodbye World'.");
       });
     });
 
@@ -562,7 +562,7 @@ describe("[Unit] ElementAssertion.test.ts", () => {
         expect(test.toHaveTextContent(/Hello/)).toBe(test);
         expect(() => test.not.toHaveTextContent(/Hello/))
           .toThrowError(AssertionError)
-          .toHaveMessage("Expected element <Text ... /> NOT to have text content matching 'RegExp: /Hello/'.");
+          .toHaveMessage("Expected element <Text ... /> NOT to have text content matching '/Hello/'.");
       });
     });
 
@@ -576,7 +576,7 @@ describe("[Unit] ElementAssertion.test.ts", () => {
         expect(test.not.toHaveTextContent(/Goodbye/)).toBeEqual(test);
         expect(() => test.toHaveTextContent(/Goodbye/))
           .toThrowError(AssertionError)
-          .toHaveMessage("Expected element <Text ... /> to have text content matching 'RegExp: /Goodbye/'.");
+          .toHaveMessage("Expected element <Text ... /> to have text content matching '/Goodbye/'.");
       });
     });
 
@@ -597,7 +597,7 @@ describe("[Unit] ElementAssertion.test.ts", () => {
         expect(test.toHaveTextContent("Hello World")).toBe(test);
         expect(() => test.not.toHaveTextContent("Hello World"))
           .toThrowError(AssertionError)
-          .toHaveMessage("Expected element <View ... /> NOT to have text content matching 'String: \"Hello World\"'.");
+          .toHaveMessage("Expected element <View ... /> NOT to have text content matching 'Hello World'.");
       });
     });
 
@@ -618,7 +618,7 @@ describe("[Unit] ElementAssertion.test.ts", () => {
         expect(test.not.toHaveTextContent("Goodbye World")).toBeEqual(test);
         expect(() => test.toHaveTextContent("Goodbye World"))
           .toThrowError(AssertionError)
-          .toHaveMessage("Expected element <View ... /> to have text content matching 'String: \"Goodbye World\"'.");
+          .toHaveMessage("Expected element <View ... /> to have text content matching 'Goodbye World'.");
       });
     });
 
@@ -634,7 +634,7 @@ describe("[Unit] ElementAssertion.test.ts", () => {
           .toThrowError(AssertionError)
           .toHaveMessage(
             "Expected element <Text ... /> NOT to have text content matching " +
-            "'Function: text => text.startsWith(\"Hello\")'.",
+            "'text => text.startsWith(\"Hello\")'.",
           );
       });
     });
@@ -651,7 +651,7 @@ describe("[Unit] ElementAssertion.test.ts", () => {
           .toThrowError(AssertionError)
           .toHaveMessage(
             "Expected element <Text ... /> to have text content matching " +
-            "'Function: text => text.startsWith(\"Goodbye\")'.",
+            "'text => text.startsWith(\"Goodbye\")'.",
           );
       });
     });
@@ -666,7 +666,7 @@ describe("[Unit] ElementAssertion.test.ts", () => {
         expect(test.not.toHaveTextContent("Hello World")).toBeEqual(test);
         expect(() => test.toHaveTextContent("Hello World"))
           .toThrowError(AssertionError)
-          .toHaveMessage("Expected element <View ... /> to have text content matching 'String: \"Hello World\"'.");
+          .toHaveMessage("Expected element <View ... /> to have text content matching 'Hello World'.");
       });
     });
 
@@ -680,7 +680,7 @@ describe("[Unit] ElementAssertion.test.ts", () => {
         expect(test.not.toHaveTextContent(/Hello/)).toBeEqual(test);
         expect(() => test.toHaveTextContent(/Hello/))
           .toThrowError(AssertionError)
-          .toHaveMessage("Expected element <View ... /> to have text content matching 'RegExp: /Hello/'.");
+          .toHaveMessage("Expected element <View ... /> to have text content matching '/Hello/'.");
       });
     });
 
@@ -696,7 +696,7 @@ describe("[Unit] ElementAssertion.test.ts", () => {
           .toThrowError(AssertionError)
           .toHaveMessage(
             "Expected element <View ... /> to have text content matching " +
-            "'Function: text => text.startsWith(\"Hello\")'.",
+            "'text => text.startsWith(\"Hello\")'.",
           );
       });
     });


### PR DESCRIPTION
## Description
Adds a new `toHaveTextContent` matcher to the React Native module, allowing you to match an element’s text content using a string, a regular expression, or a custom function.